### PR TITLE
Closes #12 / Create Terraform project foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,18 @@ htmlcov/
 .vagrant/
 infrastructure/vagrant/config/vagrant.env
 node_modules/
+
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+*.tfplan
+crash.log
+crash.*.log
+backend.hcl
+
+# Credentials and private keys
+*.pem
+*.key

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.44.0"
+  constraints = "~> 7.44.0"
+  hashes = [
+    "h1:NqGVZh36a/xy8odgCGOE+xW3kOUlWlFHy3Oj3w6cCDA=",
+    "zh:0f01a648c6f423aef3981cf5ceacbffd6da7c4cea09ee32281e1b8d097dea450",
+    "zh:466c2115c5ec2e28db03e2c5ee167b58cb07fc546e57c92b7128c165ca35074b",
+    "zh:4d9172e50e29305b08af59d02adeaedcac019073e80959a23dac63792c27cf23",
+    "zh:5222149fc04cc34341efb90fdc51d8ebd8e051fdfbfd4f4eab1f2d9945c41903",
+    "zh:75dd7746d710a2ebf5996879e4a079df868f5144504e6e1c8593542ef00164ec",
+    "zh:7a6e73ccb4a4cc383fe88adcafb8f17679b292c5b6f7b6a60463823d9f7014ba",
+    "zh:9244f674832347c0190ecbdb22872b4ba8476c507622107c096304957680e65c",
+    "zh:99c53c2bb648ed96f3cbc46de9aecdaf561c8a55a4d3ead1b170fd48a69d1103",
+    "zh:a13bbcf868994dace18fb4be393af01fef2d5139580a8ce2a12893f1dce66e83",
+    "zh:b03b1e792797300bb3357116bd44438a0892d5b80c9e1e9accb06a62dc162f69",
+    "zh:ef0d8cb202b466520875f37b261f3e58a0f53b0f4c969ae81a006afb9158ba31",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,22 @@
+# Terraform Infrastructure
+
+Terraform configuration for the GCP deployment of the Oil Price Tracker.
+
+## Structure
+
+- `modules/network` - VPC, subnet, routing, NAT, and firewall resources.
+- `modules/bastion` - bastion host and SSH access resources.
+- `modules/compute` - application VM resources.
+
+## Requirements
+
+- Terraform 1.15.x
+- Google Cloud credentials through Application Default Credentials
+- Access to the target GCP project
+
+## Configuration
+
+Create a local variable file:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars

--- a/infrastructure/terraform/locals.tf
+++ b/infrastructure/terraform/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  name_prefix = var.name_prefix
+
+  common_labels = merge(
+    {
+      application = "oil-price-tracker"
+      environment = var.environment
+      managed_by  = "terraform"
+    },
+    var.common_labels
+  )
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,5 @@
+# Root Terraform module.
+#
+# Network and bastion resources will be added in issue #13.
+# Application compute resources will be added in issue #14.
+

--- a/infrastructure/terraform/providers.tf
+++ b/infrastructure/terraform/providers.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -1,0 +1,10 @@
+project_id  = "your-gcp-project-id"
+region      = "europe-central2"
+zone        = "europe-central2-a"
+name_prefix = "oil"
+environment = "dev"
+
+common_labels = {
+  project = "oil-price-tracker"
+  team    = "ua-academy"
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,59 @@
+variable "project_id" {
+  description = "Google Cloud project ID"
+  type        = string
+
+  validation {
+    condition     = length(var.project_id) >= 6 && length(var.project_id) <= 30
+    error_message = "project_id must contain between 6 and 30 characters."
+  }
+}
+
+variable "region" {
+  description = "Google Cloud region"
+  type        = string
+  default     = "europe-central2"
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))
+    error_message = "region must be a valid GCP region, for example europe-central2."
+  }
+}
+
+variable "zone" {
+  description = "Google Cloud zone"
+  type        = string
+  default     = "europe-central2-a"
+
+  validation {
+    condition     = startswith(var.zone, "${var.region}-")
+    error_message = "zone must belong to the selected region."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix used for GCP resource names"
+  type        = string
+  default     = "oil"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "name_prefix must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "stage", "prod"], var.environment)
+    error_message = "environment must be one of: dev, stage, prod."
+  }
+}
+
+variable "common_labels" {
+  description = "Additional labels applied to managed GCP resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.15.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.44.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #12

## Changes
- Added Terraform project structure
- Configured Google Cloud provider and version constraints
- Added project, region, zone, naming, and label variables
- Added variable validation
- Added Terraform state and security ignore rules
- Added example tfvars file
- Added Terraform README
- Added reusable module directories for network, bastion, and compute

## Validation
- `terraform fmt -check -recursive` passed
- `terraform init` passed
- `terraform validate` passed