### PR TITLE
Close #11 Create reusable workflows to build and publish images to GHCR

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,42 @@
+name: Publish application images
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  fetcher:
+    name: Publish Fetcher image
+    uses: ./.github/workflows/reusable-build-image.yaml
+    with:
+      image-name: ghcr.io/${{ github.repository_owner }}/push-and-pray/fetcher
+      dockerfile: infrastructure/docker/Dockerfile.fetcher
+      context: .
+      description: Petroscope scheduled oil-price fetcher
+
+  history:
+    name: Publish History image
+    uses: ./.github/workflows/reusable-build-image.yaml
+    with:
+      image-name: ghcr.io/${{ github.repository_owner }}/push-and-pray/history
+      dockerfile: infrastructure/docker/Dockerfile.history
+      context: .
+      description: Petroscope price history API and event consumer
+
+  ui:
+    name: Publish UI image
+    uses: ./.github/workflows/reusable-build-image.yaml
+    with:
+      image-name: ghcr.io/${{ github.repository_owner }}/push-and-pray/ui
+      dockerfile: infrastructure/docker/Dockerfile.ui
+      context: .
+      description: Petroscope web UI and backend service
+

--- a/.github/workflows/reusable-build-image.yaml
+++ b/.github/workflows/reusable-build-image.yaml
@@ -1,0 +1,73 @@
+name: Build and publish an application image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Fully qualified GHCR image name
+        required: true
+        type: string
+      dockerfile:
+        description: Path to the Dockerfile
+        required: true
+        type: string
+      context:
+        description: Docker build context
+        required: true
+        type: string
+      description:
+        description: OCI image description
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image-name }}
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=integration,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.description=${{ inputs.description }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=${{ inputs.image-name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}
+

--- a/README.md
+++ b/README.md
@@ -291,6 +291,29 @@ logging driver.
 Journald is limited by provisioning to 200 MB and seven days per VM. Grafana and Loki are
 not part of this project.
 
+### Published application images
+
+GitHub Actions builds and publishes every application image to GitHub Container Registry:
+
+| Application | Image |
+|---|---|
+| Fetcher | `ghcr.io/<owner>/push-and-pray/fetcher` |
+| History | `ghcr.io/<owner>/push-and-pray/history` |
+| UI | `ghcr.io/<owner>/push-and-pray/ui` |
+
+Replace `<owner>` with the lowercase GitHub account or organization that owns the
+repository. Every published image receives the full commit SHA as an immutable tag.
+Additional moving tags identify the delivery channel:
+
+- pushes to `develop`: `develop` and `integration`;
+- pushes to `main`: `main` and `latest`;
+- release tags matching `v*`: the Git tag and, for semantic versions, normalized version
+  and `major.minor` tags (for example `v1.4.2`, `1.4.2`, and `1.4`).
+
+Images are pushed only after a successful Buildx build. The registry login uses the
+workflow-scoped `GITHUB_TOKEN`, which GitHub Actions masks in logs; workflows do not print
+or pass the token as a Docker build argument.
+
 ## Local development
 
 Local development requires Python 3.12+, uv, Go 1.24+, Node.js, PostgreSQL, RabbitMQ, and


### PR DESCRIPTION
closes  #11
- [x] Create reusable workflow logic for building one application image.
- [x] Accept the image name, Dockerfile, and build context as inputs.
- [x] Use Docker Buildx.
- [x] Authenticate to `ghcr.io` using `GITHUB_TOKEN`.
- [x] Use the minimum required workflow permissions.
- [x] Build and publish the Fetcher image.
- [x] Build and publish the History image.
- [x] Build and publish the UI image.
- [x] Publish integration images after changes merge into `develop`.
- [x] Publish release images after changes merge into `main` or a release tag.
- [x] Tag every image with an immutable commit SHA.
- [x] Add appropriate branch or version tags.
- [x] Add OCI source, revision, and description labels.
- [x] Use Docker build caching.
- [x] Inspect existing Dockerfiles and optimize them only where there is a measurable benefit.
- [x] Do not publish an image when its build fails.
- [x] Document the final image names.
- [x] Document the image tag convention.
- [x] Confirm registry credentials are not exposed in logs.