### PR TITLE
Create PostgreSQL tables for price events and UI sessions

### DIFF
--- a/database/migrations/003_create_price_events.sql
+++ b/database/migrations/003_create_price_events.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS price_events (
+    id UUID PRIMARY KEY,
+    event_key VARCHAR(200) NOT NULL,
+    schema_version SMALLINT NOT NULL DEFAULT 1,
+    payload JSONB NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processing_started_at TIMESTAMPTZ,
+    processed_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_price_events_event_key UNIQUE (event_key),
+    CONSTRAINT ck_price_events_schema_version_positive CHECK (schema_version > 0),
+    CONSTRAINT ck_price_events_payload_object CHECK (jsonb_typeof(payload) = 'object'),
+    CONSTRAINT ck_price_events_status_known CHECK (
+        status IN ('pending', 'processing', 'processed', 'failed')
+    ),
+    CONSTRAINT ck_price_events_attempts_non_negative CHECK (attempts >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS ix_price_events_ready
+    ON price_events (available_at, created_at)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS ix_price_events_processing_started_at
+    ON price_events (processing_started_at)
+    WHERE status = 'processing';
+
+COMMENT ON TABLE price_events IS
+    'Durable PostgreSQL queue for versioned price-observation events.';
+COMMENT ON COLUMN price_events.event_key IS
+    'Producer-defined idempotency key; retries reuse the same value.';
+COMMENT ON COLUMN price_events.payload IS
+    'Complete versioned price-observation event encoded as a JSON object.';
+COMMENT ON COLUMN price_events.status IS
+    'Processing state: pending, processing, processed, or failed.';
+COMMENT ON COLUMN price_events.attempts IS
+    'Number of processing attempts started by History workers.';
+COMMENT ON COLUMN price_events.available_at IS
+    'Earliest time at which a pending event may be claimed.';
+COMMENT ON COLUMN price_events.processing_started_at IS
+    'Time at which the current or most recent processing attempt started.';
+
+COMMIT;

--- a/database/migrations/004_create_ui_sessions.sql
+++ b/database/migrations/004_create_ui_sessions.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ui_sessions (
+    session_id VARCHAR(128) PRIMARY KEY,
+    preferences JSONB NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_ui_sessions_id_length CHECK (char_length(session_id) BETWEEN 32 AND 128),
+    CONSTRAINT ck_ui_sessions_preferences_object CHECK (
+        jsonb_typeof(preferences) = 'object'
+    )
+);
+
+CREATE INDEX IF NOT EXISTS ix_ui_sessions_expires_at
+    ON ui_sessions (expires_at);
+
+COMMENT ON TABLE ui_sessions IS
+    'Server-side UI preferences with application-managed sliding expiration.';
+COMMENT ON COLUMN ui_sessions.preferences IS
+    'Complete validated UI preference document encoded as a JSON object.';
+COMMENT ON COLUMN ui_sessions.expires_at IS
+    'Expiration time refreshed by the UI service when a session is accessed.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds the PostgreSQL structures required to replace RabbitMQ event storage and Redis UI session storage.

### Price events

- Adds a durable `price_events` table.
- Stores the complete versioned event payload as `JSONB`.
- Uses a unique event key for idempotent producer retries.
- Tracks processing status, attempts, retry availability, errors, and timestamps.
- Adds indexes for finding ready events and recovering events left in processing.

### UI sessions

- Adds a `ui_sessions` table.
- Stores validated UI preferences as `JSONB`.
- Tracks session creation, updates, and expiration.
- Adds an index for expired-session lookup.
- Enforces the existing session identifier length requirements.

## Validation

Validated using an isolated PostgreSQL 16 instance:

- [x] Applied the existing migrations in order.
- [x] Applied both new migrations successfully.
- [x] Reapplied both new migrations successfully.
- [x] Confirmed existing `price_observations` data remained unchanged.
- [x] Confirmed duplicate event keys do not create duplicate events.
- [x] Confirmed default event status and attempt count.
- [x] Confirmed invalid event statuses are rejected.
- [x] Confirmed event payloads must be JSON objects.
- [x] Confirmed UI preferences must be JSON objects.
- [x] Confirmed invalid session identifier lengths are rejected.
- [x] Confirmed all expected indexes were created.

## Scope

This PR defines the database contract only. Fetcher, History, and UI integration will be implemented in their respective tickets.

Closes #4