### PR TITLE
Feature/redis to postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,6 @@ RABBITMQ_URL=amqp://oil_tracker:change-me@127.0.0.1:5672/oil_tracker
 RABBITMQ_EXCHANGE=oil.price.events
 RABBITMQ_QUEUE=history.price-observations
 RABBITMQ_ROUTING_KEY=prices.observed
-REDIS_URL=redis://127.0.0.1:6379/0
 SESSION_TTL_SECONDS=2592000
 SESSION_COOKIE_SECURE=false
 LISTEN_ADDRESS=:8002

--- a/database/migrations/003_create_sessions.sql
+++ b/database/migrations/003_create_sessions.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id VARCHAR(128) PRIMARY KEY,
+    preferences JSONB NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_sessions_expires_at
+    ON sessions (expires_at);
+
+COMMIT;

--- a/infrastructure/docker/compose.ui.yaml
+++ b/infrastructure/docker/compose.ui.yaml
@@ -1,38 +1,6 @@
 name: petroscope-ui
 
 services:
-  redis:
-    image: ${REDIS_IMAGE:-redis:8.2.8-bookworm}
-    restart: unless-stopped
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      TZ: UTC
-    command:
-      - redis-server
-      - --appendonly
-      - "yes"
-      - --appendfsync
-      - everysec
-      - --maxmemory-policy
-      - noeviction
-      - --requirepass
-      - ${REDIS_PASSWORD}
-    ports:
-      - "${UI_LAN_IP:?UI_LAN_IP is required}:6379:6379"
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD-SHELL", "redis-cli --no-auth-warning -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 10s
-    stop_grace_period: 20s
-    logging:
-      driver: journald
-      options:
-        tag: petroscope/redis
-
   ui:
     image: petroscope-ui:local
     build:
@@ -46,16 +14,15 @@ services:
     init: true
     environment:
       HISTORY_SERVICE_URL: http://${HISTORY_LAN_IP:?HISTORY_LAN_IP is required}:8001
-      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+      DATABASE_URL: postgresql+psycopg://oil_tracker:${DB_PASSWORD:?DB_PASSWORD is required}@${DB_LAN_IP:?DB_LAN_IP is required}:5432/oil_tracker
       SESSION_TTL_SECONDS: "2592000"
       SESSION_COOKIE_SECURE: "false"
       LOG_LEVEL: INFO
       TZ: UTC
     ports:
       - "${UI_LAN_IP}:8080:8080"
-    depends_on:
-      redis:
-        condition: service_healthy
+
+
     healthcheck:
       test:
         - CMD
@@ -74,6 +41,3 @@ services:
       options:
         tag: petroscope/ui
 
-volumes:
-  redis_data:
-    name: petroscope-redis-data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "httpx>=0.28,<1",
     "psycopg[binary]>=3.2,<4",
     "pydantic-settings>=2.9,<3",
-    "redis>=8,<9",
     "sqlalchemy>=2.0,<3",
     "uvicorn[standard]>=0.34,<1",
 ]

--- a/services/ui/backend/src/ui_service/config.py
+++ b/services/ui/backend/src/ui_service/config.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    database_url: str = "postgresql+psycopg://oil_tracker:change-me@localhost:5432/oil_tracker"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/ui/backend/src/ui_service/database.py
+++ b/services/ui/backend/src/ui_service/database.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from .config import get_settings
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+engine = create_engine(
+    get_settings().database_url,
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=10
+)
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def get_db() -> Generator[Session, None, None]:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/services/ui/backend/src/ui_service/main.py
+++ b/services/ui/backend/src/ui_service/main.py
@@ -6,15 +6,20 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
-import redis.asyncio as redis
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
-from redis.exceptions import RedisError
 
 from .sessions import SessionPreferences, resolve_session_id
 
+from datetime import datetime, timedelta, timezone
+from sqlalchemy.orm import Session
+from fastapi import Depends
+from sqlalchemy import text
+
+from .database import get_db
+from .repository import get_session, create_session, refresh_session
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
@@ -22,7 +27,6 @@ logging.basicConfig(
 
 STATIC_DIR = Path(__file__).parent / "static"
 HISTORY_SERVICE_URL = os.getenv("HISTORY_SERVICE_URL", "http://localhost:8001").rstrip("/")
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME", "petroscope_session")
 SESSION_TTL_SECONDS = int(os.getenv("SESSION_TTL_SECONDS", "2592000"))
 SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "false").lower() == "true"
@@ -31,18 +35,10 @@ SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "false").lower() == "
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app.state.client = httpx.AsyncClient(base_url=HISTORY_SERVICE_URL, timeout=10.0)
-    app.state.redis = redis.Redis.from_url(
-        REDIS_URL,
-        decode_responses=True,
-        socket_connect_timeout=5,
-        socket_timeout=5,
-        health_check_interval=30,
-    )
     try:
         yield
     finally:
         await app.state.client.aclose()
-        await app.state.redis.aclose()
 
 
 app = FastAPI(
@@ -72,17 +68,17 @@ async def proxy_get(request: Request, path: str, params: dict | None = None) -> 
 
 
 @app.get("/health", tags=["operations"])
-async def health(request: Request) -> dict[str, str]:
+async def health(request: Request, db: Session = Depends(get_db)) -> dict[str, str]:
     try:
         upstream = await request.app.state.client.get("/health")
         upstream.raise_for_status()
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=503, detail="History Service is unavailable") from exc
     try:
-        await request.app.state.redis.ping()
-    except RedisError as exc:
-        raise HTTPException(status_code=503, detail="Redis is unavailable") from exc
-    return {"status": "ok", "history": "connected", "redis": "connected"}
+        db.execute(text("SELECT 1"))
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="Database is unavailable") from exc
+    return {"status": "ok", "history": "connected", "database": "connected"}
 
 
 def _set_session_cookie(response: Response, session_id: str) -> None:
@@ -96,45 +92,33 @@ def _set_session_cookie(response: Response, session_id: str) -> None:
         path="/",
     )
 
-
-def _session_key(session_id: str) -> str:
-    return f"ui:session:{session_id}"
-
-
 @app.get(
     "/api/session/preferences",
     response_model=SessionPreferences,
     tags=["session"],
 )
-async def get_session_preferences(request: Request, response: Response) -> SessionPreferences:
+async def get_session_preferences(
+    request: Request,
+    response: Response,
+    db: Annotated[Session, Depends(get_db)],
+) -> SessionPreferences:
     session_id, _ = resolve_session_id(request.cookies.get(SESSION_COOKIE_NAME))
-    key = _session_key(session_id)
-    try:
-        stored = await request.app.state.redis.get(key)
-        if stored is None:
+    record = get_session(db, session_id)
+    if record is None:
+        preferences = SessionPreferences()
+        create_session(db, session_id, preferences.model_dump(), _new_expiry())
+    else:
+        try:
+            preferences = SessionPreferences.model_validate(record.preferences)
+        except ValidationError:
             preferences = SessionPreferences()
-            await request.app.state.redis.set(
-                key,
-                preferences.model_dump_json(),
-                ex=SESSION_TTL_SECONDS,
-            )
+            record.preferences = preferences.model_dump()
+            record.expires_at = _new_expiry()
+            db.commit()
         else:
-            try:
-                preferences = SessionPreferences.model_validate_json(stored)
-            except ValidationError:
-                preferences = SessionPreferences()
-                await request.app.state.redis.set(
-                    key,
-                    preferences.model_dump_json(),
-                    ex=SESSION_TTL_SECONDS,
-                )
-            else:
-                await request.app.state.redis.expire(key, SESSION_TTL_SECONDS)
-    except RedisError as exc:
-        raise HTTPException(status_code=503, detail="Redis is unavailable") from exc
+            refresh_session(db, session_id, _new_expiry())
     _set_session_cookie(response, session_id)
     return preferences
-
 
 @app.put(
     "/api/session/preferences",
@@ -145,16 +129,16 @@ async def update_session_preferences(
     payload: SessionPreferences,
     request: Request,
     response: Response,
+    db: Annotated[Session, Depends(get_db)],
 ) -> SessionPreferences:
     session_id, _ = resolve_session_id(request.cookies.get(SESSION_COOKIE_NAME))
-    try:
-        await request.app.state.redis.set(
-            _session_key(session_id),
-            payload.model_dump_json(),
-            ex=SESSION_TTL_SECONDS,
-        )
-    except RedisError as exc:
-        raise HTTPException(status_code=503, detail="Redis is unavailable") from exc
+    record = get_session(db, session_id)
+    if record is None:
+        create_session(db, session_id, payload.model_dump(), _new_expiry())
+    else:
+        record.preferences = payload.model_dump()
+        record.expires_at = _new_expiry()
+        db.commit()
     _set_session_cookie(response, session_id)
     return payload
 

--- a/services/ui/backend/src/ui_service/main.py
+++ b/services/ui/backend/src/ui_service/main.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from .sessions import SessionPreferences, resolve_session_id
 
 from datetime import datetime, timedelta, timezone
+from typing import Annotated
 from sqlalchemy.orm import Session
 from fastapi import Depends
 from sqlalchemy import text
@@ -79,6 +80,10 @@ async def health(request: Request, db: Session = Depends(get_db)) -> dict[str, s
     except Exception as exc:
         raise HTTPException(status_code=503, detail="Database is unavailable") from exc
     return {"status": "ok", "history": "connected", "database": "connected"}
+
+
+def _new_expiry() -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=SESSION_TTL_SECONDS)
 
 
 def _set_session_cookie(response: Response, session_id: str) -> None:

--- a/services/ui/backend/src/ui_service/models.py
+++ b/services/ui/backend/src/ui_service/models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    String,
+    DateTime,
+
+)
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .database import Base
+
+class SessionRecord(Base):
+    __tablename__ = "sessions"
+
+    session_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    preferences: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    

--- a/services/ui/backend/src/ui_service/models.py
+++ b/services/ui/backend/src/ui_service/models.py
@@ -17,6 +17,7 @@ class SessionRecord(Base):
     __tablename__ = "sessions"
 
     session_id: Mapped[str] = mapped_column(String(128), primary_key=True)
-    preferences: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    preferences: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    

--- a/services/ui/backend/src/ui_service/models.py
+++ b/services/ui/backend/src/ui_service/models.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 
 from sqlalchemy import (
+    JSON,
     String,
     DateTime,
-
 )
 
 from sqlalchemy.dialects.postgresql import JSONB

--- a/services/ui/backend/src/ui_service/repository.py
+++ b/services/ui/backend/src/ui_service/repository.py
@@ -2,24 +2,32 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
+
 from .models import SessionRecord
 
-def get_session(db:Session, session_id: str) -> SessionRecord | None:
+
+def get_session(db: Session, session_id: str) -> SessionRecord | None:
     statement = select(SessionRecord).where(
         SessionRecord.session_id == session_id,
         SessionRecord.expires_at > func.now(),
     )
     return db.execute(statement).scalar_one_or_none()
 
-def create_session(db: Session, session_id: str, preferences: str, expires_at: datetime) -> SessionRecord:
-    sessionRecord = SessionRecord(session_id=session_id, preferences=preferences, expires_at=expires_at)
-    db.add(sessionRecord)
+
+def create_session(
+    db: Session, session_id: str, preferences: dict, expires_at: datetime
+) -> SessionRecord:
+    session_record = SessionRecord(
+        session_id=session_id, preferences=preferences, expires_at=expires_at
+    )
+    db.add(session_record)
     db.commit()
-    return sessionRecord
+    return session_record
+
 
 def refresh_session(db: Session, session_id: str, expires_at: datetime) -> None:
-    sessionRecord = db.get(SessionRecord, session_id)
-    sessionRecord.expires_at = expires_at
+    session_record = db.get(SessionRecord, session_id)
+    session_record.expires_at = expires_at
     db.commit()

--- a/services/ui/backend/src/ui_service/repository.py
+++ b/services/ui/backend/src/ui_service/repository.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session
+from .models import SessionRecord
+
+def get_session(db:Session, session_id: str) -> SessionRecord | None:
+    statement = select(SessionRecord).where(
+        SessionRecord.session_id == session_id,
+        SessionRecord.expires_at > func.now(),
+    )
+    return db.execute(statement).scalar_one_or_none()
+
+def create_session(db: Session, session_id: str, preferences: str, expires_at: datetime) -> SessionRecord:
+    sessionRecord = SessionRecord(session_id=session_id, preferences=preferences, expires_at=expires_at)
+    db.add(sessionRecord)
+    db.commit()
+    return sessionRecord
+
+def refresh_session(db: Session, session_id: str, expires_at: datetime) -> None:
+    sessionRecord = db.get(SessionRecord, session_id)
+    sessionRecord.expires_at = expires_at
+    db.commit()

--- a/services/ui/backend/tests/conftest.py
+++ b/services/ui/backend/tests/conftest.py
@@ -1,0 +1,36 @@
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from ui_service.database import Base, get_db
+from ui_service.main import app
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def client_db_override(db_session: Session):
+    def _get_db_override() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _get_db_override
+    yield db_session
+    app.dependency_overrides.clear()

--- a/services/ui/backend/tests/test_repository.py
+++ b/services/ui/backend/tests/test_repository.py
@@ -1,0 +1,38 @@
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from ui_service.repository import create_session, get_session, refresh_session
+
+
+def _future(minutes: int = 30) -> datetime:
+    return datetime.now(UTC) + timedelta(minutes=minutes)
+
+
+def _past(minutes: int = 30) -> datetime:
+    return datetime.now(UTC) - timedelta(minutes=minutes)
+
+
+def test_get_session_returns_none_when_missing(db_session: Session) -> None:
+    assert get_session(db_session, "does-not-exist") is None
+
+
+def test_create_session_can_be_read_back(db_session: Session) -> None:
+    create_session(db_session, "abc123", {"range": "30"}, _future())
+    record = get_session(db_session, "abc123")
+    assert record is not None
+    assert record.preferences == {"range": "30"}
+
+
+def test_expired_session_is_treated_as_missing(db_session: Session) -> None:
+    create_session(db_session, "expired-one", {"range": "30"}, _past())
+    assert get_session(db_session, "expired-one") is None
+
+
+def test_refresh_session_extends_expiry(db_session: Session) -> None:
+    create_session(db_session, "refresh-me", {"range": "30"}, _future(minutes=5))
+    new_expiry = _future(minutes=30)
+    refresh_session(db_session, "refresh-me", new_expiry)
+    record = get_session(db_session, "refresh-me")
+    assert record is not None
+    assert record.expires_at.replace(tzinfo=UTC) == new_expiry

--- a/services/ui/backend/tests/test_session_api.py
+++ b/services/ui/backend/tests/test_session_api.py
@@ -1,34 +1,14 @@
 import asyncio
 
 import httpx
+from sqlalchemy.orm import Session
 
 from ui_service.main import app
 
 
-class FakeRedis:
-    def __init__(self) -> None:
-        self.values: dict[str, str] = {}
-
-    async def get(self, key: str) -> str | None:
-        return self.values.get(key)
-
-    async def set(self, key: str, value: str, *, ex: int) -> bool:
-        self.values[key] = value
-        return True
-
-    async def expire(self, key: str, ttl: int) -> bool:
-        return key in self.values and ttl > 0
-
-    async def aclose(self) -> None:
-        pass
-
-
-async def session_round_trip() -> None:
+async def session_round_trip(db_session: Session) -> None:
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        fake_redis = FakeRedis()
-        app.state.redis = fake_redis
-
         initial = await client.get("/api/session/preferences")
         assert initial.status_code == 200
         assert initial.json()["selected"] is None
@@ -59,8 +39,8 @@ async def session_round_trip() -> None:
         assert restored.json()["smooth"] is False
 
 
-def test_session_preferences_round_trip_through_redis() -> None:
-    asyncio.run(session_round_trip())
+def test_session_preferences_round_trip_through_postgres(client_db_override: Session) -> None:
+    asyncio.run(session_round_trip(client_db_override))
 
 
 def test_spa_fallback_serves_vite_entrypoint() -> None:

--- a/services/ui/frontend/src/App.tsx
+++ b/services/ui/frontend/src/App.tsx
@@ -224,7 +224,7 @@ function App() {
           <span><i className={loadState === "ready" ? "online" : "pending"} />History / PostgreSQL</span>
           <span>
             {sessionState === "saved" ? <Check size={13} /> : sessionState === "local" ? <CloudOff size={13} /> : <Activity size={13} />}
-            {sessionState === "saved" ? "Redis session saved" : sessionState === "local" ? "Local defaults" : "Saving session"}
+            {sessionState === "saved" ? "Session saved" : sessionState === "local" ? "Local defaults" : "Saving session"}
           </span>
           <time>{lastRead ? `${formatDateTime(lastRead)} UTC` : "Waiting for data"}</time>
         </div>


### PR DESCRIPTION
Closes #7

- Added a 'sessions' table with `session_id`, `preferences` and `expires_at'
- Added 'SessionRecord' model, sqlalchemy engine/session setup, and a small repository layer (get session, create session, refresh session)
- Rewrote 'api/session/preferences' and '/health' to read/write postgres instead of redis
- Removed the redis service from 'compose.ui.yaml', the redis python dependency and all remaining redis references
- replaced the redis-based session with postgres repository test