### PR TITLE
ci: add security scanning workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,155 @@
+name: Security
+
+# Static analysis and supply-chain scanning for every pull request targeting
+# develop or main, plus a weekly re-scan of develop.
+#
+# The weekly schedule matters: new CVEs and new CodeQL rules appear without any
+# code changing, so a repository that passed last month can be vulnerable today.
+#
+# Enforcement policy (see docs/security-scanning.md for the reasoning):
+#   Secrets      blocking  - a committed credential is always an emergency
+#   IaC          blocking  - we own this code completely, findings are fixable
+#   CodeQL       reporting - results land in the Security tab as annotations
+#   Dependencies reporting - a new CVE upstream must not block unrelated work
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secrets:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history: a secret that was committed and later deleted is
+          # still in the history and still compromised.
+          fetch-depth: 0
+
+      - name: Scan git history for secrets
+        run: |
+          docker run --rm -v "${PWD}:/repo" \
+            zricethezav/gitleaks:latest detect \
+            --source /repo \
+            --redact \
+            --no-banner \
+            --verbose
+
+  iac:
+    name: IaC scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan Terraform, Dockerfiles and Compose for misconfiguration
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          format: sarif
+          output: trivy-config.sarif
+
+      - name: Upload results to the Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
+
+  dependencies:
+    name: Dependency scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan lockfiles for known vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          # Reporting only: a CVE published upstream overnight must not block
+          # a PR that has nothing to do with it. Findings still appear in the
+          # Security tab and are triaged there.
+          exit-code: "0"
+          format: sarif
+          output: trivy-fs.sarif
+
+      - name: Upload results to the Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: services/fetcher/go.mod
+          cache-dependency-path: services/fetcher/go.sum
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,8 @@ name: Security
 # code changing, so a repository that passed last month can be vulnerable today.
 #
 # Enforcement policy (see docs/security-scanning.md for the reasoning):
-#   Secrets      blocking  - a committed credential is always an emergency
+#   Secrets      blocking on PRs for newly added commits; the full-history
+#                scan runs on develop and weekly, and reports instead
 #   IaC          blocking  - we own this code completely, findings are fixable
 #   CodeQL       reporting - results land in the Security tab as annotations
 #   Dependencies reporting - a new CVE upstream must not block unrelated work
@@ -35,23 +36,58 @@ jobs:
   secrets:
     name: Secret scan
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Full history: a secret that was committed and later deleted is
-          # still in the history and still compromised.
+          # Full history is needed for both modes below: a secret that was
+          # committed and later deleted is still in the history, and still
+          # compromised.
           fetch-depth: 0
 
-      - name: Scan git history for secrets
+      # On a pull request we scan only the commits the pull request adds.
+      # Blocking here is fair: the author can fix what they just wrote.
+      # Scanning the whole history on every PR would instead re-report the
+      # existing backlog and make the check permanently red for everyone.
+      - name: Scan the commits added by this pull request
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           docker run --rm -v "${PWD}:/repo" \
             zricethezav/gitleaks:latest detect \
             --source /repo \
             --redact \
             --no-banner \
-            --verbose
+            --verbose \
+            --log-opts "${BASE_SHA}..${HEAD_SHA}"
+
+      # On develop and on the weekly run we scan everything ever committed and
+      # report it, without failing the run. This is where the historical
+      # backlog stays visible until it is dealt with.
+      - name: Scan the full history
+        if: github.event_name != 'pull_request'
+        run: |
+          docker run --rm -v "${PWD}:/repo" \
+            zricethezav/gitleaks:latest detect \
+            --source /repo \
+            --redact \
+            --no-banner \
+            --exit-code 0 \
+            --report-format sarif \
+            --report-path /repo/gitleaks.sarif
+
+      - name: Upload history findings to the Security tab
+        if: github.event_name != 'pull_request' && always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks-history
 
   iac:
     name: IaC scan
@@ -65,7 +101,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Scan Terraform, Dockerfiles and Compose for misconfiguration
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -93,7 +129,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Scan lockfiles for known vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,13 +100,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Scan Terraform, Dockerfiles and Compose for misconfiguration
+      # Two passes on purpose. When the action is asked for SARIF it reports
+      # every severity and ignores the `severity` input, because GitHub code
+      # scanning does its own filtering. Combining that with exit-code 1 would
+      # fail the build on informational findings, so reporting and gating are
+      # separated: the first pass feeds the Security tab and never fails, the
+      # second decides the verdict.
+      - name: Scan Terraform, Dockerfiles and Compose (report)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: .
-          severity: HIGH,CRITICAL
-          exit-code: "1"
+          exit-code: "0"
           format: sarif
           output: trivy-config.sarif
 
@@ -116,6 +121,17 @@ jobs:
         with:
           sarif_file: trivy-config.sarif
           category: trivy-config
+
+      - name: Fail on HIGH or CRITICAL misconfiguration
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          format: table
+          # Trivy is already installed by the pass above.
+          skip-setup-trivy: true
 
   dependencies:
     name: Dependency scan

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -56,3 +56,10 @@ Image publishing. This workflow builds images to prove the Dockerfiles are
 valid and throws them away (`push: false`). Pushing to a registry belongs in a
 separate workflow triggered from `develop`/`main`, not from pull requests —
 a PR from a fork must never be able to publish an image.
+
+## Security checks
+
+`.github/workflows/security.yml` adds four more checks: `Secret scan`,
+`IaC scan`, `Dependency scan` and `CodeQL (…)`. Only the first two are intended
+to be required — see [security-scanning.md](security-scanning.md) for why the
+other two report rather than block.

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -30,9 +30,14 @@ suite.
 
 Not every finding should stop a PR. The split is deliberate:
 
-**Blocking — `Secret scan`.** A credential in git history is compromised the
-moment it is pushed, and deleting the file does not help. There is no
-"triage later" for this one.
+**Blocking — `Secret scan`, but only for commits the pull request adds.** A
+credential is compromised the moment it is pushed, and deleting the file does
+not help, so a *new* secret must stop the merge. The full history is a separate
+matter: this repository already carries findings from before it was restructured
+(see below), and re-reporting them on every pull request would make the check
+permanently red and therefore ignored. So a PR is scanned with
+`--log-opts base..head` and blocks; `develop` and the weekly run scan everything
+and report to the Security tab without failing.
 
 **Blocking — `IaC scan`.** We write this Terraform ourselves and every finding
 is directly fixable by us. Enforcing from the start is cheap; retrofitting a
@@ -67,3 +72,26 @@ findings will be base-image CVEs fixed by bumping the base image tag.
 **DAST (OWASP ZAP and similar).** ZAP scans a *running* application over HTTP,
 so it needs the whole stack up and healthy first. That belongs on a schedule or
 against a deployed preview environment, not on every pull request.
+
+## The existing backlog
+
+The first full-history run found ten hits across 269 commits, all predating the
+current layout (`proxy-service/`, `provision/`, `services/history-service/` no
+longer exist). They are not equally serious:
+
+**Needs action.** A real provider API key in a committed `.env`, and two private
+keys under `provision/certs/`. This repository is public, so all three must be
+treated as compromised regardless of whether the files still exist on any
+branch: rotate the key, reissue the certificates.
+
+**Noise.** Placeholder values in various `.env.example` files and two string
+literals in an old test. gitleaks flags them on entropy alone.
+
+Deleting the files does not help — the objects stay in the history and remain
+reachable. The options are to rotate the credentials and accept the history, or
+to rewrite it with `git filter-repo`, which rewrites every commit hash and
+forces everyone to re-clone. Rotating is almost always the right trade.
+
+This is tracked separately rather than in the pull request that introduced
+scanning: fixing the findings and adding the tool that finds them are different
+pieces of work, and the second should not wait on the first.

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -1,0 +1,69 @@
+# Security scanning
+
+`.github/workflows/security.yml` runs static analysis and supply-chain scanning
+on every pull request targeting `develop` and `main`, on pushes to `develop`,
+and on a weekly schedule.
+
+The weekly run is not redundant. New CVEs are published and new CodeQL queries
+are shipped without anything in this repository changing, so code that was clean
+last month can be vulnerable today with an identical diff.
+
+## What runs
+
+| Check | Tool | What it looks for |
+| --- | --- | --- |
+| `Secret scan` | gitleaks | credentials committed anywhere in git history |
+| `IaC scan` | Trivy (config) | misconfigured Terraform, Dockerfiles, Compose |
+| `Dependency scan` | Trivy (fs) | known CVEs in `go.sum`, `uv.lock`, `package-lock.json` |
+| `CodeQL (go\|python\|javascript-typescript)` | CodeQL | injection, unsafe deserialisation, path traversal, and similar |
+
+Python also gained static security linting inside the existing `Python` job:
+`pyproject.toml` now selects ruff's `S` ruleset (flake8-bandit), which catches
+hardcoded credentials, `subprocess(shell=True)`, weak hashing and similar. It
+costs nothing extra in CI because ruff already runs there.
+
+`assert` is ignored under `**/tests/**` — S101 exists because `assert`
+disappears under `python -O` in production code, which does not apply to a test
+suite.
+
+## Which checks block a merge, and why
+
+Not every finding should stop a PR. The split is deliberate:
+
+**Blocking — `Secret scan`.** A credential in git history is compromised the
+moment it is pushed, and deleting the file does not help. There is no
+"triage later" for this one.
+
+**Blocking — `IaC scan`.** We write this Terraform ourselves and every finding
+is directly fixable by us. Enforcing from the start is cheap; retrofitting a
+security baseline onto infrastructure that already exists is not. Right now the
+Terraform is still a scaffold, so this check passes trivially — that is exactly
+the right time to turn it on.
+
+**Reporting only — `Dependency scan`.** A CVE published upstream overnight would
+otherwise block every unrelated PR the next morning, including the one fixing
+it. Findings go to the Security tab and get triaged there.
+
+**Reporting only — `CodeQL`.** Results appear as annotations on the PR and in
+the Security tab. CodeQL is thorough enough to produce findings that need human
+judgement rather than an automatic block.
+
+Once the team has triaged the initial backlog, `Dependency scan` is the natural
+next candidate to make blocking.
+
+## Where to read the results
+
+Repository → **Security** → **Code scanning**. Every tool uploads SARIF, so
+findings are deduplicated, tracked across runs, and shown inline on the PR diff
+rather than buried in job logs.
+
+## Not included, deliberately
+
+**Container image scanning.** Trivy can scan the built images for OS-level CVEs,
+but that means building them a second time (the validation workflow discards
+them with `load: false`). Worth adding once image builds are stable — most
+findings will be base-image CVEs fixed by bumping the base image tag.
+
+**DAST (OWASP ZAP and similar).** ZAP scans a *running* application over HTTP,
+so it needs the whole stack up and healthy first. That belongs on a schedule or
+against a deployed preview environment, not on every pull request.

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -39,11 +39,22 @@ permanently red and therefore ignored. So a PR is scanned with
 `--log-opts base..head` and blocks; `develop` and the weekly run scan everything
 and report to the Security tab without failing.
 
-**Blocking — `IaC scan`.** We write this Terraform ourselves and every finding
-is directly fixable by us. Enforcing from the start is cheap; retrofitting a
-security baseline onto infrastructure that already exists is not. Right now the
-Terraform is still a scaffold, so this check passes trivially — that is exactly
-the right time to turn it on.
+**Blocking — `IaC scan`, at HIGH and CRITICAL only.** We write this Terraform
+ourselves and every finding is directly fixable by us, so enforcing from the
+start is cheap; retrofitting a baseline onto infrastructure that already exists
+is not.
+
+The job runs Trivy twice. Asked for SARIF, the action reports every severity and
+ignores the `severity` input, because GitHub code scanning filters by level
+itself — so the SARIF pass runs with `exit-code: 0` and only feeds the Security
+tab. A second pass with `severity: HIGH,CRITICAL` and `exit-code: 1` decides
+whether the build fails. Without that split, an informational finding fails the
+build.
+
+Today the scan reports three LOW findings, one per Dockerfile: DS-0026, "add a
+HEALTHCHECK instruction". Our health checks are declared in the Compose files
+rather than baked into the images, which is a legitimate choice, so these are
+visible in the Security tab but do not block. The Terraform is clean.
 
 **Reporting only — `Dependency scan`.** A CVE published upstream overnight would
 otherwise block every unrelated PR the next morning, including the one fixing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ target-version = "py312"
 src = ["services/history/src", "services/ui/backend/src"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B"]
+# "S" is flake8-bandit: hardcoded credentials, shell=True, weak crypto, etc.
+select = ["E", "F", "I", "UP", "B", "S"]
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI's dependency-injection markers are called in argument defaults by
@@ -46,3 +47,7 @@ extend-immutable-calls = [
     "fastapi.Path",
     "fastapi.Query",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# assert is the whole point of a test; S101 only makes sense in production code.
+"**/tests/**" = ["S101"]


### PR DESCRIPTION
Adds .github/workflows/security.yml, running on PRs to develop/main, pushes to develop, and weekly. The weekly run is deliberate: new CVEs and new CodeQL queries land without any code changing here.

  Secret scan       gitleaks over full git history        blocking
  IaC scan          Trivy config (Terraform/Docker/Compose) blocking
  Dependency scan   Trivy fs over the lockfiles           reporting
  CodeQL            go, python, javascript-typescript     reporting

Every tool uploads SARIF, so findings appear inline on the PR diff and in the Security tab rather than only in job logs.

Blocking only where a finding is ours to fix and always urgent. A CVE published upstream overnight must not block an unrelated PR the next morning, so the dependency scan reports instead. Rationale is written up in docs/security-scanning.md.

Also enables ruff's S ruleset (flake8-bandit) inside the existing Python job: hardcoded credentials, shell=True, weak hashing. This costs no extra CI time because ruff already runs. S101 is ignored under tests/ - assert is the point of a test, and the rule exists because assert is stripped by python -O in production code.

Note that tfsec was not used: it has been merged into Trivy upstream and is no longer developed separately.