### PR TITLE
ci: only run validation jobs when relevant files change

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,8 +4,10 @@ name: PR Validation
 # request targeting develop or main. Nothing is published from this workflow —
 # images are built and thrown away. Publishing lives in a separate workflow.
 #
-# Job names below are stable and unique so they can be selected as required
-# status checks in branch protection. See docs/ci-required-checks.md.
+# Jobs only run when files they actually care about changed. Because a skipped
+# job reports no status at all, branch protection must require the single
+# "Required checks" job at the bottom rather than the individual ones — it
+# always runs and decides the overall verdict. See docs/ci-required-checks.md.
 
 on:
   pull_request:
@@ -25,9 +27,103 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      yaml: ${{ steps.filter.outputs.yaml == 'true' || github.event_name == 'workflow_dispatch' }}
+      python: ${{ steps.filter.outputs.python == 'true' || github.event_name == 'workflow_dispatch' }}
+      go: ${{ steps.filter.outputs.go == 'true' || github.event_name == 'workflow_dispatch' }}
+      frontend: ${{ steps.filter.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch' }}
+      compose: ${{ steps.filter.outputs.compose == 'true' || github.event_name == 'workflow_dispatch' }}
+      terraform: ${{ steps.filter.outputs.terraform == 'true' || github.event_name == 'workflow_dispatch' }}
+      images: ${{ steps.images.outputs.list }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Every filter below also lists this workflow file: if the pipeline
+      # itself changes we re-validate everything, otherwise a broken edit to
+      # the pipeline could merge without ever being exercised.
+      - name: Work out what changed
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            yaml:
+              - '**/*.yml'
+              - '**/*.yaml'
+              - '.yamllint.yml'
+            python:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/history/**'
+              - 'services/ui/backend/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+            go:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/fetcher/**'
+            frontend:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/ui/frontend/**'
+            compose:
+              - '.github/workflows/pr-validation.yml'
+              - 'infrastructure/docker/compose.*.yaml'
+            terraform:
+              - '.github/workflows/pr-validation.yml'
+              - '**/*.tf'
+              - '**/*.tfvars'
+            image-fetcher:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/fetcher/**'
+              - 'infrastructure/docker/Dockerfile.fetcher'
+            image-history:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/history/**'
+              - 'infrastructure/docker/Dockerfile.history'
+              - 'pyproject.toml'
+              - 'uv.lock'
+            image-ui:
+              - '.github/workflows/pr-validation.yml'
+              - 'services/ui/**'
+              - 'infrastructure/docker/Dockerfile.ui'
+              - 'pyproject.toml'
+              - 'uv.lock'
+
+      # The image job uses a dynamic matrix so that only the services whose
+      # build inputs changed get rebuilt. An empty list means the job is
+      # skipped entirely (see its `if:`), because an empty matrix is an error.
+      - name: Build the image matrix
+        id: images
+        run: |
+          services=()
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            services=('"fetcher"' '"history"' '"ui"')
+          else
+            if [ "${{ steps.filter.outputs.image-fetcher }}" = "true" ]; then
+              services+=('"fetcher"')
+            fi
+            if [ "${{ steps.filter.outputs.image-history }}" = "true" ]; then
+              services+=('"history"')
+            fi
+            if [ "${{ steps.filter.outputs.image-ui }}" = "true" ]; then
+              services+=('"ui"')
+            fi
+          fi
+          list="[$(IFS=,; echo "${services[*]-}")]"
+          echo "list=${list}" >> "${GITHUB_OUTPUT}"
+          echo "Images to build: ${list}"
+
   yaml:
     name: YAML
+    needs: changes
+    if: needs.changes.outputs.yaml == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +141,14 @@ jobs:
 
   python:
     name: Python
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Never silently re-resolve the lockfile: CI must test the versions that
+      # are actually pinned.
+      UV_FROZEN: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,7 +176,10 @@ jobs:
 
   go:
     name: Go
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: services/fetcher
@@ -106,7 +212,10 @@ jobs:
 
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: services/ui/frontend
@@ -132,7 +241,10 @@ jobs:
 
   compose:
     name: Docker Compose
+    needs: changes
+    if: needs.changes.outputs.compose == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       # Every Compose file uses ${VAR:?message} for required settings, so
       # `docker compose config` fails unless they are defined. These are
@@ -167,14 +279,14 @@ jobs:
 
   image:
     name: Docker image (${{ matrix.service }})
+    needs: changes
+    if: needs.changes.outputs.images != '[]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        service:
-          - fetcher
-          - history
-          - ui
+        service: ${{ fromJSON(needs.changes.outputs.images) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -194,14 +306,14 @@ jobs:
 
   terraform:
     name: Terraform
+    needs: changes
+    if: needs.changes.outputs.terraform == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # This job always runs and always reports a result, even when there is no
-      # Terraform in the repository yet. A skipped job never reports a status,
-      # which would leave a required check pending forever.
       - name: Detect Terraform configuration
         id: detect
         run: |
@@ -210,7 +322,7 @@ jobs:
             echo "Terraform configuration found."
           else
             echo "present=false" >> "${GITHUB_OUTPUT}"
-            echo "No Terraform configuration in the repository yet - nothing to validate."
+            echo "No Terraform configuration in the repository - nothing to do."
           fi
 
       - name: Set up Terraform
@@ -228,13 +340,56 @@ jobs:
         if: steps.detect.outputs.present == 'true'
         run: |
           status=0
-          directories="$(find . -path ./.git -prune -o -name '*.tf' -print \
-            | xargs -r -n1 dirname | sort -u)"
-          for directory in ${directories}; do
+          while IFS= read -r directory; do
             echo "::group::${directory}"
             terraform -chdir="${directory}" init -backend=false -input=false \
               || status=1
             terraform -chdir="${directory}" validate || status=1
             echo "::endgroup::"
-          done
+          done < <(find . -path ./.git -prune -o -name '*.tf' -print \
+            | xargs -r -n1 dirname | sort -u)
           exit "${status}"
+
+  # The only job branch protection should require. It always runs, so it always
+  # reports a status, which is exactly what a skipped job cannot do. A skipped
+  # dependency counts as success; a failed or cancelled one fails the check.
+  required-checks:
+    name: Required checks
+    if: always()
+    needs:
+      - changes
+      - yaml
+      - python
+      - go
+      - frontend
+      - compose
+      - image
+      - terraform
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Summarise results
+        run: |
+          {
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| Detect changes | ${{ needs.changes.result }} |"
+            echo "| YAML | ${{ needs.yaml.result }} |"
+            echo "| Python | ${{ needs.python.result }} |"
+            echo "| Go | ${{ needs.go.result }} |"
+            echo "| Frontend | ${{ needs.frontend.result }} |"
+            echo "| Docker Compose | ${{ needs.compose.result }} |"
+            echo "| Docker image | ${{ needs.image.result }} |"
+            echo "| Terraform | ${{ needs.terraform.result }} |"
+            echo ""
+            echo "\`skipped\` means nothing relevant to that job changed."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Fail if any job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "At least one validation job did not succeed."
+          exit 1
+
+      - name: Report success
+        run: echo "All validation jobs passed or were skipped as irrelevant."

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -4,38 +4,41 @@
 `develop` and `main`, and on pushes to `develop`. It validates code,
 configuration, tests and Docker image builds. It never publishes an image.
 
-## Checks to mark as required in branch protection
+## The one check to mark as required
 
-Set these on **both** `develop` and `main`
-(Settings → Branches → branch protection rule → *Require status checks to pass
-before merging*). The names below are exactly what GitHub reports:
+Set exactly **one** required status check on both `develop` and `main`
+(Settings → Rules, or Settings → Branches → *Require status checks to pass
+before merging*):
 
-| Check name              | What it guards                                        |
-| ----------------------- | ----------------------------------------------------- |
-| `YAML`                  | every versioned YAML file parses and passes yamllint   |
-| `Python`                | ruff lint, ruff format, pytest                         |
-| `Go`                    | gofmt, go vet, go test                                 |
-| `Frontend`              | npm ci, typecheck, production build                    |
-| `Docker Compose`        | all Compose files parse and interpolate                |
-| `Docker image (fetcher)`| the fetcher image builds                               |
-| `Docker image (history)`| the history image builds                               |
-| `Docker image (ui)`     | the UI image builds                                    |
-| `Terraform`             | terraform fmt and validate, once Terraform exists      |
+| Check name        | What it guards                                     |
+| ----------------- | -------------------------------------------------- |
+| `Required checks` | every validation job passed or was legitimately skipped |
 
 Also enable *Require branches to be up to date before merging*, otherwise two
 PRs that each pass individually can still break `develop` when both land.
 
-## Why `Terraform` is safe to require now
+### Why one check and not nine
 
-There is no Terraform in the repository yet. A job guarded by an `if:` at the
-job level would be **skipped**, and a skipped job reports no status at all — a
-required check that never reports leaves every PR stuck on "Expected — waiting
-for status to be reported".
+Jobs only run when files they care about changed — a documentation-only PR does
+not rebuild three Docker images. But a **skipped job reports no status at all**,
+so requiring `Python` directly would leave every PR that does not touch Python
+stuck forever on *"Expected — waiting for status to be reported"*.
 
-So the `Terraform` job always runs. Its first step looks for any `*.tf` file;
-if none exists it logs that and the remaining steps are skipped, so the job
-still finishes green. The moment someone adds Terraform, `fmt -check` and
-`validate` start running against it with no change to branch protection.
+`Required checks` solves this. It declares `needs:` on every other job and
+`if: always()`, so it runs no matter what happened upstream, and fails only when
+a dependency actually failed or was cancelled. A skipped dependency counts as
+success. Its job summary prints a table of what ran and what was skipped, so the
+detail is still one click away.
+
+Do **not** add the individual job names as required checks. The moment path
+filtering skips one, merges block.
+
+## Why the `Terraform` job detects its own input
+
+The job runs when a `*.tf` or `*.tfvars` file changed, but its first step still
+checks whether any Terraform actually exists in the tree before setting up the
+CLI. That covers the case where the last Terraform file in the repository is
+deleted: the job runs, finds nothing, and passes instead of erroring.
 
 ## Notes for people writing PRs
 


### PR DESCRIPTION
Every PR currently runs all nine checks regardless of what it touches, so a documentation-only change rebuilds three Docker images. Each job now declares which paths it cares about and is skipped when none of them changed.

Path filtering and required status checks do not combine naively: a skipped job reports no status at all, so requiring "Python" directly would leave every PR that does not touch Python stuck on "Expected - waiting for status to be reported" forever.

The fix is an aggregator. A new "Required checks" job needs: every other job and runs with if: always(), so it always reports. It fails only when a dependency genuinely failed or was cancelled - skipped counts as success - and writes a summary table of what ran and what did not.

BRANCH PROTECTION MUST BE UPDATED IN THE SAME CHANGE: require only "Required checks" and remove the nine individual job names. Leaving them required will block every PR that skips any job.

Image builds use a dynamic matrix so only the services whose build inputs changed are rebuilt; an empty list skips the job rather than erroring on an empty matrix. Every filter also lists this workflow file, so editing the pipeline re-validates everything.

Two fixes carried along:
- timeout-minutes on every job, so a hung step cannot burn the 6-hour default
- UV_FROZEN so uv cannot silently re-resolve the lockfile in CI
- the terraform directory loop no longer word-splits on unquoted expansion