### PR TITLE
Closes #13 / Provision network and bastion infrastructure with Terraform

### DIFF
--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "7.44.0"
   constraints = "~> 7.44.0"
   hashes = [
+    "h1:FbL1iJAQHoSxwQjQNxsejAAjVwTYe7U8/uryPgzBn6s=",
     "h1:NqGVZh36a/xy8odgCGOE+xW3kOUlWlFHy3Oj3w6cCDA=",
     "zh:0f01a648c6f423aef3981cf5ceacbffd6da7c4cea09ee32281e1b8d097dea450",
     "zh:466c2115c5ec2e28db03e2c5ee167b58cb07fc546e57c92b7128c165ca35074b",

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -20,3 +20,4 @@ Create a local variable file:
 
 ```bash
 cp terraform.tfvars.example terraform.tfvars
+```

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,5 +1,11 @@
 # Root Terraform module.
 #
 # Network and bastion resources will be added in issue #13.
+module "network" {
+  source = "./modules/network"
+
+  project_id            = var.project_id
+  region                = var.region
+}
 # Application compute resources will be added in issue #14.
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -7,5 +7,14 @@ module "network" {
   project_id            = var.project_id
   region                = var.region
 }
+
+module "bastion" {
+  source        = "./modules/bastion"
+  project_id    = var.project_id
+  zone          = var.zone
+
+  subnetwork_id = module.network.public_subnet
+  network_tag   = module.network.network_tags.bastion
+}
 # Application compute resources will be added in issue #14.
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,20 +1,31 @@
 # Root Terraform module.
-#
-# Network and bastion resources will be added in issue #13.
+
 module "network" {
   source = "./modules/network"
 
-  project_id            = var.project_id
-  region                = var.region
+  project_id  = var.project_id
+  region      = var.region
+  name_prefix = local.name_prefix
+  labels      = local.common_labels
+
+  ssh_port              = var.ssh_port
+  bastion_allowed_cidrs = var.bastion_allowed_cidrs
 }
 
 module "bastion" {
-  source        = "./modules/bastion"
-  project_id    = var.project_id
-  zone          = var.zone
+  source = "./modules/bastion"
 
-  subnetwork_id = module.network.public_subnet
+  project_id  = var.project_id
+  region      = var.region
+  zone        = var.zone
+  name_prefix = local.name_prefix
+  labels      = local.common_labels
+
+  # The bastion is the only instance in the public subnet.
+  subnetwork_id = module.network.public_subnet.id
   network_tag   = module.network.network_tags.bastion
+
+  ssh_port  = var.ssh_port
+  ssh_users = var.ssh_users
 }
 # Application compute resources will be added in issue #14.
-

--- a/infrastructure/terraform/modules/bastion/README.md
+++ b/infrastructure/terraform/modules/bastion/README.md
@@ -1,0 +1,210 @@
+# Bastion module
+
+Creates the single SSH entry point into the VPC: one small hardened instance in
+the public subnet, a static external IP, a dedicated service account, and per
+person public keys installed through instance metadata.
+
+## What it creates
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| `google_compute_instance` | `<prefix>-bastion` | Jump host, `e2-micro`, Shielded VM |
+| `google_compute_address` | `<prefix>-bastion-ip` | Static IP, so allow-lists survive rebuilds |
+| `google_service_account` | `<prefix>-bastion-sa` | Dedicated identity with almost no permissions |
+| `google_project_iam_member` | - | `logging.logWriter`, `monitoring.metricWriter` for the audit trail |
+
+The firewall rules live in the [network module](../network/README.md). This
+module only tags the instance (`network_tag`) so those rules match it.
+
+## Hardening
+
+`templates/sshd-hardening.sh.tftpl` runs at boot and is idempotent. It moves sshd
+to `ssh_port`, and sets `PermitRootLogin no`, `PasswordAuthentication no`,
+`AuthenticationMethods publickey`, `MaxAuthTries 3`, `LoginGraceTime 30` and
+`LogLevel VERBOSE`. `AllowTcpForwarding` stays on - `ProxyJump` needs it - while
+agent forwarding, X11 and tunnelling are off. The script also handles images that
+start sshd through `ssh.socket`, and runs `sshd -t` before restarting, so a bad
+config cannot lock the team out.
+
+Instance metadata sets `block-project-ssh-keys = TRUE`: project-wide keys are
+ignored, and the only way in is a key listed in this module.
+
+## SSH keys
+
+`ssh_users` is a map of `linux-username -> one public key`. Validation rejects
+anything that is not exactly one OpenSSH **public** key line, and specifically
+rejects text containing `PRIVATE KEY`.
+
+**Private keys are never generated, accepted or stored by Terraform.** Each
+person creates their own keypair locally and hands over the `.pub` half only.
+The private half never leaves their machine, so it can never end up in the
+repository or in Terraform state.
+
+## Usage
+
+```hcl
+module "bastion" {
+  source = "./modules/bastion"
+
+  project_id = var.project_id
+  region     = var.region
+  zone       = var.zone
+
+  subnetwork_id = module.network.public_subnet.id
+  network_tag   = module.network.network_tags.bastion
+
+  ssh_port  = 18832
+  ssh_users = {
+    tabula = file("~/keys/tabula.pub")
+  }
+}
+```
+
+Outputs: `bastion_public_ip`, `bastion_private_ip`, `bastion_name`,
+`bastion_zone`, `bastion_network_tags`, `bastion_service_account`, `ssh_port`,
+`ssh_users`, `bastion_ssh_command`, `bastion_proxy_jump_command`.
+
+## Access procedure
+
+### 1. The person requesting access
+
+Generate a keypair (Ed25519, passphrase-protected) and send **only** the `.pub`
+file:
+
+```bash
+ssh-keygen -t ed25519 -a 100 -C "tabula@laptop" -f ~/.ssh/oil_bastion
+```
+
+Send `~/.ssh/oil_bastion.pub` and the public egress address you will connect
+from. Never send or paste `~/.ssh/oil_bastion`.
+
+### 2. The infrastructure owner
+
+Add one entry per person to `terraform.tfvars`, and add the source address to
+`bastion_allowed_cidrs` (see the [network module](../network/README.md)):
+
+```hcl
+ssh_users = {
+  tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... tabula@laptop"
+}
+```
+
+Open a PR, get it reviewed, then apply:
+
+```bash
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+Metadata updates take effect within seconds - the instance is not recreated.
+
+### 3. Connecting
+
+```bash
+terraform output bastion_ssh_command
+ssh -i ~/.ssh/oil_bastion -p 18832 tabula@<bastion-public-ip>
+```
+
+Private instances are never reachable directly. Jump through the bastion:
+
+```bash
+ssh -i ~/.ssh/oil_bastion -J tabula@<bastion-public-ip>:18832 -p 18832 tabula@10.10.1.5
+```
+
+Or make it permanent in `~/.ssh/config`:
+
+```
+Host oil-bastion
+  HostName <bastion-public-ip>
+  User tabula
+  Port 18832
+  IdentityFile ~/.ssh/oil_bastion
+  IdentitiesOnly yes
+
+Host oil-private-*
+  User tabula
+  Port 18832
+  IdentityFile ~/.ssh/oil_bastion
+  IdentitiesOnly yes
+  ProxyJump oil-bastion
+```
+
+Then `ssh oil-bastion`, or `ssh oil-private-app` after adding a `HostName` for it.
+
+To reach the database from a laptop, forward the port through the chain instead
+of opening it - the database accepts connections from application instances only:
+
+```bash
+ssh -N -L 5432:10.10.1.6:5432 oil-private-app
+```
+
+### 4. Revoking access
+
+Remove the person's entry from `ssh_users` (and their CIDR from
+`bastion_allowed_cidrs` if it was personal), then apply. Confirm with the
+verification steps below that the key is gone.
+
+## Verifying bastion access
+
+**The bastion answers on the approved port, and only there.** The first command
+must print an SSH banner, the second must time out:
+
+```bash
+nc -vz -w 5 $(terraform output -raw bastion_public_ip) 18832
+nc -vz -w 5 $(terraform output -raw bastion_public_ip) 22
+```
+
+**Login works with the key and nothing else:**
+
+```bash
+ssh -i ~/.ssh/oil_bastion -p 18832 tabula@$(terraform output -raw bastion_public_ip) 'hostname; whoami'
+```
+
+**Password login is refused** - this must fail with `Permission denied (publickey)`:
+
+```bash
+ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no \
+  -p 18832 tabula@$(terraform output -raw bastion_public_ip)
+```
+
+**sshd really listens on the approved port** (run on the bastion):
+
+```bash
+sudo ss -tlnp | grep sshd
+sudo sshd -T | grep -E '^(port|permitrootlogin|passwordauthentication|pubkeyauthentication)'
+```
+
+Expected: `port 18832`, `permitrootlogin no`, `passwordauthentication no`,
+`pubkeyauthentication yes`.
+
+**The installed keys match `ssh_users`, and nothing else is there:**
+
+```bash
+terraform output ssh_users
+gcloud compute instances describe oil-bastion --zone=europe-central2-a \
+  --format='value(metadata.items.filter("key:ssh-keys").extract("value"))' | cut -d' ' -f1,3
+```
+
+**The private path only works through the bastion.** The first must fail (no
+route from the internet), the second must succeed:
+
+```bash
+ssh -o ConnectTimeout=5 -p 18832 tabula@10.10.1.5
+ssh -J tabula@$(terraform output -raw bastion_public_ip):18832 -p 18832 tabula@10.10.1.5 'hostname'
+```
+
+**Access from a non-approved address is refused.** From an address outside
+`bastion_allowed_cidrs` (mobile hotspot, VPN off), the connection must time out
+rather than prompt for anything.
+
+**Sessions are auditable.** Firewall logging and the bastion's logging role make
+each connection visible:
+
+```bash
+gcloud logging read \
+  'logName=~"compute.googleapis.com%2Ffirewall" AND jsonPayload.rule_details.reference=~"oil-allow-ssh-to-bastion"' \
+  --limit=10 --format='table(timestamp,jsonPayload.connection.src_ip,jsonPayload.disposition)'
+
+ssh -p 18832 tabula@$(terraform output -raw bastion_public_ip) \
+  'sudo journalctl -u ssh -n 50 | grep Accepted'
+```

--- a/infrastructure/terraform/modules/bastion/bastion.tf
+++ b/infrastructure/terraform/modules/bastion/bastion.tf
@@ -41,7 +41,7 @@ resource "google_compute_instance" "bastion" {
 
   zone         = var.zone
   machine_type = var.bastion_machine_type
-  tags         = [local.tag_bastion, var.network_tag]
+  tags         = local.instance_tags
   labels       = local.labels
 
   # Never route other hosts' traffic through the bastion.

--- a/infrastructure/terraform/modules/bastion/bastion.tf
+++ b/infrastructure/terraform/modules/bastion/bastion.tf
@@ -1,0 +1,95 @@
+resource "google_service_account" "bastion" {
+  project      = var.project_id
+  account_id   = "${local.prefix}-bastion-sa"
+  display_name = "${local.prefix} bastion host"
+  description  = "Dedicated identity for the bastion. Deliberately has almost no permissions."
+}
+
+# Session logs are the audit trail for "who used the bastion, when".
+resource "google_project_iam_member" "bastion_log_writer" {
+  count = var.grant_bastion_logging_roles ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+resource "google_project_iam_member" "bastion_metric_writer" {
+  count = var.grant_bastion_logging_roles ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# A reserved static IP so the address in the team's ~/.ssh/config and in the
+# corporate firewall allow-list survives instance recreation.
+resource "google_compute_address" "bastion" {
+  project      = var.project_id
+  name         = "${local.prefix}-bastion-ip"
+  description  = "Static external IP of the bastion host."
+  region       = var.region
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+  labels       = local.labels
+}
+
+resource "google_compute_instance" "bastion" {
+  project     = var.project_id
+  name        = "${local.prefix}-bastion"
+  description = "SSH jump host. Only sshd on port ${var.ssh_port} is exposed, only to approved source ranges."
+
+  zone         = var.zone
+  machine_type = var.bastion_machine_type
+  tags         = [local.tag_bastion, var.network_tag]
+  labels       = local.labels
+
+  # Never route other hosts' traffic through the bastion.
+  can_ip_forward = false
+
+  boot_disk {
+    auto_delete = true
+
+    initialize_params {
+      image  = var.bastion_image
+      size   = var.bastion_disk_size_gb
+      type   = "pd-balanced"
+      labels = local.labels
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnetwork_id
+
+    # The single external IP in this module.
+    access_config {
+      nat_ip       = google_compute_address.bastion.address
+      network_tier = "PREMIUM"
+    }
+  }
+
+  metadata                = local.common_metadata
+  metadata_startup_script = local.startup_script
+
+  service_account {
+    email = google_service_account.bastion.email
+    # cloud-platform + narrow IAM roles is the current recommendation; legacy
+    # per-scope restriction is not a security boundary.
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  scheduling {
+    preemptible         = var.bastion_preemptible
+    automatic_restart   = !var.bastion_preemptible
+    provisioning_model  = var.bastion_preemptible ? "SPOT" : "STANDARD"
+    on_host_maintenance = var.bastion_preemptible ? "TERMINATE" : "MIGRATE"
+  }
+
+  allow_stopping_for_update = true
+}

--- a/infrastructure/terraform/modules/bastion/locals.tf
+++ b/infrastructure/terraform/modules/bastion/locals.tf
@@ -2,25 +2,23 @@ locals {
   prefix = var.name_prefix
 
   # Network tags are the handle firewall rules use to select instances.
-  # Nothing is reachable unless it carries the right tag.
+  # The tag comes from the network module; the local one is the same value and is
+  # kept only so the module still names its instance correctly when used standalone.
   tag_bastion = "${local.prefix}-bastion"
 
-  # "user:public-key" lines, one per person. Empty when OS Login is enabled.
+  instance_tags = distinct(compact([local.tag_bastion, var.network_tag]))
+
+  # "user:public-key" lines, one per person.
   ssh_keys_metadata = join("\n", [
     for user, key in var.ssh_users : "${user}:${trimspace(key)}"
   ])
 
-  # Common metadata for every instance in this module.
-  # Built as one map with nulls filtered out, so the type is always map(string).
   common_metadata = {
-    for k, v in {
-      # Project-wide SSH keys are ignored: access is decided here, not by whoever
-      # happens to have project metadata permissions.
-      block-project-ssh-keys = "TRUE"
-      enable-oslogin         = "FALSE"
-      serial-port-enable = "FALSE"
-      ssh-keys           = local.ssh_keys_metadata
-    } : k => v if v != null
+    # Project-wide SSH keys are ignored: access is decided here, not by whoever
+    # happens to have project metadata permissions.
+    block-project-ssh-keys = "TRUE"
+    serial-port-enable     = "FALSE"
+    ssh-keys               = local.ssh_keys_metadata
   }
 
   startup_script = templatefile("${path.module}/templates/sshd-hardening.sh.tftpl", {
@@ -29,8 +27,8 @@ locals {
 
   labels = merge(
     {
-      managed-by = "terraform"
-      module     = "network-bastion"
+      managed_by = "terraform"
+      module     = "bastion"
     },
     var.labels
   )

--- a/infrastructure/terraform/modules/bastion/locals.tf
+++ b/infrastructure/terraform/modules/bastion/locals.tf
@@ -1,0 +1,37 @@
+locals {
+  prefix = var.name_prefix
+
+  # Network tags are the handle firewall rules use to select instances.
+  # Nothing is reachable unless it carries the right tag.
+  tag_bastion = "${local.prefix}-bastion"
+
+  # "user:public-key" lines, one per person. Empty when OS Login is enabled.
+  ssh_keys_metadata = join("\n", [
+    for user, key in var.ssh_users : "${user}:${trimspace(key)}"
+  ])
+
+  # Common metadata for every instance in this module.
+  # Built as one map with nulls filtered out, so the type is always map(string).
+  common_metadata = {
+    for k, v in {
+      # Project-wide SSH keys are ignored: access is decided here, not by whoever
+      # happens to have project metadata permissions.
+      block-project-ssh-keys = "TRUE"
+      enable-oslogin         = "FALSE"
+      serial-port-enable = "FALSE"
+      ssh-keys           = local.ssh_keys_metadata
+    } : k => v if v != null
+  }
+
+  startup_script = templatefile("${path.module}/templates/sshd-hardening.sh.tftpl", {
+    ssh_port = var.ssh_port
+  })
+
+  labels = merge(
+    {
+      managed-by = "terraform"
+      module     = "network-bastion"
+    },
+    var.labels
+  )
+}

--- a/infrastructure/terraform/modules/bastion/outputs.tf
+++ b/infrastructure/terraform/modules/bastion/outputs.tf
@@ -1,0 +1,49 @@
+output "bastion_name" {
+  description = "Name of the bastion instance."
+  value       = google_compute_instance.bastion.name
+}
+
+output "bastion_zone" {
+  description = "Zone the bastion runs in."
+  value       = google_compute_instance.bastion.zone
+}
+
+output "bastion_public_ip" {
+  description = "Static external IP of the bastion. This is the only address the team connects to."
+  value       = google_compute_address.bastion.address
+}
+
+output "bastion_private_ip" {
+  description = "Internal IP of the bastion inside the VPC."
+  value       = google_compute_instance.bastion.network_interface[0].network_ip
+}
+
+output "bastion_network_tags" {
+  description = "Network tags carried by the bastion. The network module's firewall rules match on these."
+  value       = google_compute_instance.bastion.tags
+}
+
+output "bastion_service_account" {
+  description = "Email of the dedicated bastion service account."
+  value       = google_service_account.bastion.email
+}
+
+output "ssh_port" {
+  description = "Port sshd listens on. The default port 22 is closed."
+  value       = var.ssh_port
+}
+
+output "ssh_users" {
+  description = "Usernames that have a public key installed on the bastion. Keys themselves are not exported."
+  value       = sort(keys(var.ssh_users))
+}
+
+output "bastion_ssh_command" {
+  description = "Ready-to-run SSH command for the bastion. Replace <user> with your own username."
+  value       = "ssh -p ${var.ssh_port} <user>@${google_compute_address.bastion.address}"
+}
+
+output "bastion_proxy_jump_command" {
+  description = "Template for reaching a private instance through the bastion with ProxyJump."
+  value       = "ssh -J <user>@${google_compute_address.bastion.address}:${var.ssh_port} -p ${var.ssh_port} <user>@<private-instance-ip>"
+}

--- a/infrastructure/terraform/modules/bastion/templates/sshd-hardening.sh.tftpl
+++ b/infrastructure/terraform/modules/bastion/templates/sshd-hardening.sh.tftpl
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Rendered by Terraform. Moves sshd to the team-approved non-default port and
+# hardens it. Idempotent: safe to re-run on every boot.
+set -euo pipefail
+
+SSH_PORT="${ssh_port}"
+DROPIN_DIR=/etc/ssh/sshd_config.d
+DROPIN_FILE="$DROPIN_DIR/10-team-hardening.conf"
+
+mkdir -p "$DROPIN_DIR"
+
+cat >"$DROPIN_FILE" <<EOF
+# Managed by Terraform - do not edit by hand.
+Port $SSH_PORT
+Protocol 2
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PermitEmptyPasswords no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+X11Forwarding no
+AllowAgentForwarding no
+PermitTunnel no
+GatewayPorts no
+MaxAuthTries 3
+MaxSessions 10
+LoginGraceTime 30
+ClientAliveInterval 300
+ClientAliveCountMax 2
+LogLevel VERBOSE
+# Required for ProxyJump / -J and for port forwarding through the bastion.
+AllowTcpForwarding yes
+EOF
+
+chmod 0644 "$DROPIN_FILE"
+
+# Debian/Ubuntu images include the drop-in directory by default; make sure of it.
+if ! grep -qE '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' /etc/ssh/sshd_config; then
+  sed -i '1i Include /etc/ssh/sshd_config.d/*.conf' /etc/ssh/sshd_config
+fi
+
+# Any stray "Port 22" earlier in the main config would win, because sshd keeps the
+# first occurrence of a keyword.
+sed -i -E 's/^[[:space:]]*Port[[:space:]]+22[[:space:]]*$/# Port 22 (replaced by 10-team-hardening.conf)/' /etc/ssh/sshd_config
+
+# Newer images start sshd through socket activation, where the listening port comes
+# from the unit rather than from sshd_config.
+if systemctl list-unit-files 'ssh.socket' 2>/dev/null | grep -q 'ssh.socket'; then
+  mkdir -p /etc/systemd/system/ssh.socket.d
+  printf '[Socket]\nListenStream=\nListenStream=%s\n' "$SSH_PORT" \
+    >/etc/systemd/system/ssh.socket.d/10-port.conf
+  systemctl daemon-reload
+  systemctl restart ssh.socket || true
+fi
+
+# Validate before restarting: a broken config would lock everyone out.
+/usr/sbin/sshd -t
+
+systemctl restart ssh 2>/dev/null || systemctl restart sshd
+
+logger -t terraform-bootstrap "sshd now listening on port $SSH_PORT"

--- a/infrastructure/terraform/modules/bastion/variables.tf
+++ b/infrastructure/terraform/modules/bastion/variables.tf
@@ -4,15 +4,20 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "Primary region for the subnets, Cloud Router and Cloud NAT."
+  description = "Region of the bastion's static external IP. Must be the region of the subnet the bastion is placed in."
   type        = string
   default     = "europe-central2"
 }
 
 variable "zone" {
-  description = "Zone for the bastion host (and the optional example workloads)."
+  description = "Zone for the bastion host. Must belong to var.region."
   type        = string
   default     = "europe-central2-a"
+
+  validation {
+    condition     = startswith(var.zone, "${var.region}-")
+    error_message = "zone must belong to the selected region, for example europe-central2-a for region europe-central2."
+  }
 }
 
 variable "name_prefix" {
@@ -63,7 +68,7 @@ variable "grant_bastion_logging_roles" {
 }
 
 variable "ssh_port" {
-  description = "Non-default SSH port. Used both in the firewall rule and in the sshd configuration."
+  description = "Non-default SSH port. Must match the ssh_port of the network module, whose firewall rule opens it."
   type        = number
   default     = 18832
 
@@ -74,12 +79,12 @@ variable "ssh_port" {
 }
 
 variable "subnetwork_id" {
-  description = "ID of the subnet to place the bastion in."
+  description = "ID of the subnet to place the bastion in. Pass module.network.public_subnet.id."
   type        = string
 }
 
 variable "network_tag" {
-  description = "Network tag that the network module's firewall rules expect."
+  description = "Network tag the network module's firewall rules expect on the bastion. Pass module.network.network_tags.bastion."
   type        = string
 }
 
@@ -92,11 +97,10 @@ variable "ssh_users" {
     Example:
       ssh_users = {
         tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... tabula@laptop"
-        rasa  = file("~/keys/rasa.pub")
+        rasa   = file("~/keys/rasa.pub")
       }
   EOT
   type        = map(string)
-  default     = {}
 
   validation {
     condition     = length(var.ssh_users) > 0
@@ -132,15 +136,4 @@ variable "ssh_users" {
     ])
     error_message = "Exactly one public key per person is supported: each ssh_users value must be a single line."
   }
-}
-
-variable "enable_os_login" {
-  description = <<-EOT
-    Use OS Login instead of instance metadata keys. When true, ssh_users is ignored and
-    access is granted through IAM (roles/compute.osLogin + roles/iap.tunnelResourceAccessor),
-    which gives central revocation and audit logs. Set to false to use the per-person
-    metadata keys from ssh_users.
-  EOT
-  type        = bool
-  default     = false
 }

--- a/infrastructure/terraform/modules/bastion/variables.tf
+++ b/infrastructure/terraform/modules/bastion/variables.tf
@@ -1,0 +1,146 @@
+variable "project_id" {
+  description = "GCP project ID where all resources are created."
+  type        = string
+}
+
+variable "region" {
+  description = "Primary region for the subnets, Cloud Router and Cloud NAT."
+  type        = string
+  default     = "europe-central2"
+}
+
+variable "zone" {
+  description = "Zone for the bastion host (and the optional example workloads)."
+  type        = string
+  default     = "europe-central2-a"
+}
+
+variable "name_prefix" {
+  description = "Prefix for every resource name. Keep it short: GCP names are limited to 63 chars."
+  type        = string
+  default     = "oil"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "name_prefix must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "labels" {
+  description = "Labels applied to every resource that supports them."
+  type        = map(string)
+  default     = {}
+}
+
+variable "bastion_machine_type" {
+  description = "Machine type for the bastion. It only forwards SSH, so keep it tiny."
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "bastion_image" {
+  description = "Boot image for the bastion."
+  type        = string
+  default     = "debian-cloud/debian-12"
+}
+
+variable "bastion_disk_size_gb" {
+  description = "Bastion boot disk size in GB."
+  type        = number
+  default     = 20
+}
+
+variable "bastion_preemptible" {
+  description = "Run the bastion as a Spot VM. Cheaper, but it can be reclaimed at any time."
+  type        = bool
+  default     = false
+}
+
+variable "grant_bastion_logging_roles" {
+  description = "Grant the bastion service account roles/logging.logWriter and roles/monitoring.metricWriter so SSH sessions are auditable."
+  type        = bool
+  default     = true
+}
+
+variable "ssh_port" {
+  description = "Non-default SSH port. Used both in the firewall rule and in the sshd configuration."
+  type        = number
+  default     = 18832
+
+  validation {
+    condition     = var.ssh_port >= 1024 && var.ssh_port <= 65535 && var.ssh_port != 22
+    error_message = "ssh_port must be in the 1024-65535 range and must not be the default port 22."
+  }
+}
+
+variable "subnetwork_id" {
+  description = "ID of the subnet to place the bastion in."
+  type        = string
+}
+
+variable "network_tag" {
+  description = "Network tag that the network module's firewall rules expect."
+  type        = string
+}
+
+variable "ssh_users" {
+  description = <<-EOT
+    One public SSH key per person, keyed by the Linux username.
+    Values are PUBLIC keys only (ssh-ed25519 / ssh-rsa / ecdsa-* / sk-*).
+    Private keys are never accepted, never generated and never stored by this module.
+
+    Example:
+      ssh_users = {
+        tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... tabula@laptop"
+        rasa  = file("~/keys/rasa.pub")
+      }
+  EOT
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition     = length(var.ssh_users) > 0
+    error_message = "At least one person must be granted access: a bastion nobody can log into is useless."
+  }
+
+  validation {
+    condition = alltrue([
+      for u in keys(var.ssh_users) : can(regex("^[a-z_][a-z0-9_-]{0,31}$", u))
+    ])
+    error_message = "Every ssh_users key must be a valid POSIX username (lowercase, starts with a letter or underscore, max 32 chars)."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) :
+      can(regex("^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)|sk-ssh-ed25519@openssh\\.com|sk-ecdsa-sha2-nistp256@openssh\\.com) AAAA[0-9A-Za-z+/=]+", trimspace(k)))
+    ])
+    error_message = "Every ssh_users value must be a single OpenSSH PUBLIC key line starting with a supported key type."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) :
+      !can(regex("(?i)PRIVATE KEY", k))
+    ])
+    error_message = "A PRIVATE key was passed to ssh_users. Private keys must never enter Terraform code or state - pass the .pub file only."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) : length(split("\n", trimspace(k))) == 1
+    ])
+    error_message = "Exactly one public key per person is supported: each ssh_users value must be a single line."
+  }
+}
+
+variable "enable_os_login" {
+  description = <<-EOT
+    Use OS Login instead of instance metadata keys. When true, ssh_users is ignored and
+    access is granted through IAM (roles/compute.osLogin + roles/iap.tunnelResourceAccessor),
+    which gives central revocation and audit logs. Set to false to use the per-person
+    metadata keys from ssh_users.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/network/README.md
+++ b/infrastructure/terraform/modules/network/README.md
@@ -1,0 +1,162 @@
+# Network module
+
+Creates the VPC that everything else in the project runs in: one custom-mode
+network, a public subnet for the bastion, a private subnet for the application
+and database instances, explicit routing, Cloud NAT for outbound-only internet
+access, and a least-privilege firewall set.
+
+## What it creates
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| `google_compute_network` | `<prefix>-vpc` | Custom-mode VPC, no auto subnets |
+| `google_compute_subnetwork` | `<prefix>-subnet-public` | Bastion and the public-facing UI instance |
+| `google_compute_subnetwork` | `<prefix>-subnet-private` | App + database, no external IPs |
+| `google_compute_route` | `<prefix>-rt-default-internet` | Explicit `0.0.0.0/0` default route |
+| `google_compute_router` / `_router_nat` | `<prefix>-router` / `<prefix>-nat` | Egress-only internet for the private subnet |
+| `google_compute_firewall` | see below | Ingress and (optional) egress rules |
+
+Instances are selected by network tag, exported through the `network_tags`
+output: `<prefix>-bastion`, `<prefix>-app`, `<prefix>-db`, `<prefix>-ui`. An
+instance that carries no tag is reachable by nothing.
+
+The tags are a contract, not a dependency: this module creates the rules, and
+whoever creates an instance decides which tag it carries. In particular the UI
+instance does not exist yet (issue #14) - the `<prefix>-ui` rule is already in
+place and starts applying the moment that instance is tagged.
+
+```bash
+terraform output network_tags     # -> { app, bastion, db, ui }
+terraform output ui_public_ports  # -> ["80", "443"]
+```
+
+## Firewall rules
+
+Ingress (always created):
+
+| Rule | Source | Target | Ports |
+| --- | --- | --- | --- |
+| `<prefix>-allow-ssh-to-bastion` | `bastion_allowed_cidrs` | `<prefix>-bastion` | `ssh_port` |
+| `<prefix>-allow-ssh-from-bastion` | tag `<prefix>-bastion` | `<prefix>-app`, `<prefix>-db`, `<prefix>-ui` | `ssh_port` |
+| `<prefix>-allow-app-internal` | VPC subnets only | `<prefix>-app` | `app_ports` |
+| `<prefix>-allow-db-from-app` | tag `<prefix>-app` | `<prefix>-db` | `db_port` |
+| `<prefix>-allow-ui-public` | `ui_source_ranges` (`0.0.0.0/0`) | `<prefix>-ui` | `ui_public_ports` (`80`, `443`) |
+| `<prefix>-allow-internal-icmp` | VPC subnets only | all tags | ICMP |
+| `<prefix>-deny-all-ingress` (priority 65533) | `0.0.0.0/0` | everything | all |
+
+Consequences that are deliberate, not accidental:
+
+- The database port has **no** public source range at all. Only instances tagged
+  `<prefix>-app` can open it - not even the bastion.
+- Application ports are reachable from inside the VPC only. The single
+  intentionally public service is the UI, on `80`/`443` and on nothing else: a
+  `lifecycle.precondition` fails the plan if `ui_public_ports` ever overlaps
+  `app_ports` or `db_port`. A UI that needs to serve an application port gets a
+  reverse proxy in front of it, not a wider rule.
+- The UI rule is opt-out (`enable_ui_public_ingress = false`) and can be narrowed
+  to specific sources with `ui_source_ranges` while the UI is not meant to be
+  public yet.
+- Port 22 is never opened. SSH lives on `ssh_port` (default `18832`).
+- `bastion_allowed_cidrs` rejects `0.0.0.0/0`, `::/0` and any prefix shorter than
+  `/8`, in variable validation and again in a `lifecycle.precondition` on the rule.
+
+Egress is permissive by default (GCP's implied allow). Setting
+`restrict_egress = true` replaces it with a deny-all at priority 65534 plus narrow
+allows: in-VPC traffic, the metadata server, DNS/NTP, and `egress_allowed_ports`
+(default `443`). Roll that out in a non-production project first - it breaks
+anything talking to an unexpected endpoint.
+
+## Usage
+
+```hcl
+module "network" {
+  source = "./modules/network"
+
+  project_id  = var.project_id
+  region      = var.region
+  name_prefix = "oil"
+
+  ssh_port              = 18832
+  bastion_allowed_cidrs = ["203.0.113.10/32"]
+}
+```
+
+Key inputs: `public_subnet_cidr`, `private_subnet_cidr`, `ssh_port`,
+`bastion_allowed_cidrs` (required), `app_ports`, `db_port`,
+`enable_ui_public_ingress`, `ui_public_ports`, `ui_source_ranges`, `enable_nat`,
+`nat_static_ip_count`, `restrict_egress`, `enable_firewall_logging`.
+Run `terraform-docs` or read [variables.tf](variables.tf) for the full list.
+
+Key outputs: `network_id`, `public_subnet`, `private_subnet`, `network_tags`,
+`nat_name`, `nat_egress_ips`, `firewall_rules`, `egress_firewall_rules`,
+`ssh_port`, `db_port`, `ui_public_ports`.
+
+## Access procedure
+
+This module grants no access by itself: it only decides which paths exist. Two
+things have to happen for a person to get in.
+
+1. **Add the person's source address.** Append the office or VPN egress address
+   (a `/32` where possible) to `bastion_allowed_cidrs` in `terraform.tfvars`,
+   open a PR, and apply after review. Requests for `0.0.0.0/0` fail at plan time
+   by design.
+2. **Add the person's public key** to `ssh_users` of the
+   [bastion module](../bastion/README.md), which is where SSH identities live.
+
+The resulting path is fixed:
+
+```
+operator -> (ssh_port, allowed CIDR only) -> bastion -> (ssh_port, source tag) -> private instance
+private instance -> Cloud NAT -> internet   # outbound only, no inbound path
+```
+
+To revoke network access, remove the CIDR and apply. Existing sessions are not
+terminated by a firewall change, so also remove the person's key from `ssh_users`.
+
+## Verifying the network
+
+Run after `terraform apply`. Replace `oil` with your `name_prefix`.
+
+```bash
+gcloud compute networks describe oil-vpc --format='value(name,routingConfig.routingMode)'
+gcloud compute networks subnets list --filter='network~oil-vpc' \
+  --format='table(name,region,ipCidrRange,privateIpGoogleAccess)'
+```
+
+Confirm the firewall matrix, in particular that nothing internal is public:
+
+```bash
+gcloud compute firewall-rules list --filter='network~oil-vpc' \
+  --format='table(name,direction,priority,sourceRanges.list(),targetTags.list(),allowed[].map().firewall_rule().list())'
+```
+
+Expected: `0.0.0.0/0` appears only on `oil-deny-all-ingress` and on
+`oil-allow-ui-public`, and the latter carries `80,443` and nothing else. Neither
+the database port nor the application ports appear on any rule whose source is a
+public range.
+
+Once the UI instance exists and carries the `oil-ui` tag, the public side is two
+open ports and no more:
+
+```bash
+nc -vz -w 5 <ui-public-ip> 443   # succeeds
+nc -vz -w 5 <ui-public-ip> 8080  # must time out
+nc -vz -w 5 <ui-public-ip> 22    # must time out
+```
+
+Prove the database port is not reachable from outside - this must time out:
+
+```bash
+nc -vz -w 5 <bastion-public-ip> 5432
+```
+
+Check outbound connectivity from a private instance (through the bastion, see the
+[bastion README](../bastion/README.md)):
+
+```bash
+gcloud compute routers nats describe oil-nat --router=oil-router --region=europe-central2
+ssh -J <user>@<bastion-ip>:18832 -p 18832 <user>@<private-ip> 'curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com'
+```
+
+A `200` proves egress works; an inbound connection attempt to the same instance
+from the internet has no route and no rule, so it cannot succeed.

--- a/infrastructure/terraform/modules/network/firewall.tf
+++ b/infrastructure/terraform/modules/network/firewall.tf
@@ -173,3 +173,135 @@ resource "google_compute_firewall" "deny_all_ingress" {
     }
   }
 }
+# egress: least privilege outbound, opt-in via restrict_egress
+#
+# GCP's implied egress rule allows everything. These rules override it: a
+# catch-all deny at priority 65534 plus narrow allows above it. Cloud NAT still
+# provides the path to the internet - these rules decide what is allowed to use it.
+
+resource "google_compute_firewall" "egress_internal" {
+  count = var.restrict_egress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-allow-egress-internal"
+  description = "Egress between instances inside the VPC."
+
+  network   = google_compute_network.vpc.id
+  direction = "EGRESS"
+  priority  = 1000
+
+  destination_ranges = local.internal_ranges
+
+  allow {
+    protocol = "all"
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}
+
+resource "google_compute_firewall" "egress_metadata_server" {
+  count = var.restrict_egress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-allow-egress-metadata"
+  description = "Egress to the GCE metadata server: DNS, instance metadata and SSH key propagation depend on it."
+
+  network   = google_compute_network.vpc.id
+  direction = "EGRESS"
+  priority  = 1000
+
+  destination_ranges = ["169.254.169.254/32"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "53"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["53"]
+  }
+}
+
+resource "google_compute_firewall" "egress_dns_ntp" {
+  count = var.restrict_egress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-allow-egress-dns-ntp"
+  description = "Egress DNS and NTP. Without these an instance cannot resolve names or keep its clock, which breaks TLS."
+
+  network   = google_compute_network.vpc.id
+  direction = "EGRESS"
+  priority  = 1000
+
+  destination_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "udp"
+    ports    = ["53", "123"]
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["53"]
+  }
+}
+
+resource "google_compute_firewall" "egress_internet" {
+  count = var.restrict_egress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-allow-egress-internet"
+  description = "Egress to the internet on ${join(",", var.egress_allowed_ports)} only: package repositories, container registries and the upstream price API."
+
+  network   = google_compute_network.vpc.id
+  direction = "EGRESS"
+  priority  = 1000
+
+  destination_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.egress_allowed_ports
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}
+
+resource "google_compute_firewall" "deny_all_egress" {
+  count = var.restrict_egress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-deny-all-egress"
+  description = "Explicit catch-all egress deny. Overrides the permissive implied egress rule."
+
+  network   = google_compute_network.vpc.id
+  direction = "EGRESS"
+  priority  = 65534
+
+  destination_ranges = ["0.0.0.0/0"]
+
+  deny {
+    protocol = "all"
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_deny_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}

--- a/infrastructure/terraform/modules/network/firewall.tf
+++ b/infrastructure/terraform/modules/network/firewall.tf
@@ -1,0 +1,175 @@
+# public entry point: ssh to bastion from approved sources
+
+resource "google_compute_firewall" "bastion_ssh_ingress" {
+  project     = var.project_id
+  name        = "${local.prefix}-allow-ssh-to-bastion"
+  description = "Ingress SSH on port ${var.ssh_port} to the bastion from approved source ranges only."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  # Validated in variables.tf: 0.0.0.0/0 and anything broader than /8 is rejected.
+  source_ranges = var.bastion_allowed_cidrs
+  target_tags   = [local.tag_bastion]
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.ssh_port)]
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !contains([for c in var.bastion_allowed_cidrs : trimspace(c)], "0.0.0.0/0")
+      error_message = "Refusing to create an unrestricted public SSH rule: bastion_allowed_cidrs contains 0.0.0.0/0."
+    }
+  }
+}
+
+# ssh to private instances only from bastion
+
+resource "google_compute_firewall" "ssh_from_bastion" {
+  project     = var.project_id
+  name        = "${local.prefix}-allow-ssh-from-bastion"
+  description = "Ingress SSH on port ${var.ssh_port} to private instances, only from instances tagged ${local.tag_bastion}."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_tags = [local.tag_bastion]
+  target_tags = [local.tag_app, local.tag_db]
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.ssh_port)]
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}
+
+# application ports: only internal
+
+resource "google_compute_firewall" "app_internal" {
+  project     = var.project_id
+  name        = "${local.prefix}-allow-app-internal"
+  description = "Ingress to application ports ${join(",", var.app_ports)} from inside the VPC only. Never from the internet."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = local.internal_ranges
+  target_tags   = [local.tag_app]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.app_ports
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !contains(var.app_ports, tostring(var.db_port))
+      error_message = "db_port must not appear in app_ports, otherwise the database port would inherit the broader application sources."
+    }
+  }
+}
+
+# db port
+# No source_ranges at all. The only way to reach the database port is to be an
+# instance tagged as an application server. The bastion is deliberately NOT a
+# source here: an operator SSHes into an app host first, or port-forwards through
+# the bastion, which is logged.
+
+resource "google_compute_firewall" "db_from_app" {
+  project     = var.project_id
+  name        = "${local.prefix}-allow-db-from-app"
+  description = "Ingress to database port ${var.db_port} from instances tagged ${local.tag_app} only. Not reachable from the internet."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_tags = [local.tag_app]
+  target_tags = [local.tag_db]
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.db_port)]
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}
+
+# internal ICMP
+
+resource "google_compute_firewall" "internal_icmp" {
+  project     = var.project_id
+  name        = "${local.prefix}-allow-internal-icmp"
+  description = "ICMP inside the VPC for connectivity troubleshooting."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = local.internal_ranges
+  target_tags   = [local.tag_bastion, local.tag_app, local.tag_db]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+# explicit all ingress deny
+
+resource "google_compute_firewall" "deny_all_ingress" {
+  project     = var.project_id
+  name        = "${local.prefix}-deny-all-ingress"
+  description = "Explicit catch-all ingress deny. Anything not matched by a rule above lands here."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 65533
+
+  source_ranges = ["0.0.0.0/0"]
+
+  deny {
+    protocol = "all"
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_deny_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+}

--- a/infrastructure/terraform/modules/network/firewall.tf
+++ b/infrastructure/terraform/modules/network/firewall.tf
@@ -34,19 +34,65 @@ resource "google_compute_firewall" "bastion_ssh_ingress" {
   }
 }
 
+# public entry point: http/https to the ui service
+#
+# The UI instance itself is created by the compute work (issue #14). This rule is
+# the network-side contract for it: whatever that instance turns out to be, it
+# becomes publicly reachable on ui_public_ports the moment it carries the
+# <name_prefix>-ui tag, and on nothing else. Ingress in GCP selects targets by
+# tag, not by destination range, so no IP has to be known here in advance.
+
+resource "google_compute_firewall" "ui_public_ingress" {
+  count = var.enable_ui_public_ingress ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-allow-ui-public"
+  description = "Ingress ${join(",", var.ui_public_ports)} from ${join(",", var.ui_source_ranges)} to instances tagged ${local.tag_ui}. The only intentionally public service."
+
+  network   = google_compute_network.vpc.id
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = var.ui_source_ranges
+  target_tags   = [local.tag_ui]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.ui_public_ports
+  }
+
+  dynamic "log_config" {
+    for_each = local.firewall_log_config
+
+    content {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+
+  lifecycle {
+    # The public rule must never become a way in to an internal port. If the UI
+    # ever needs to serve on an application port, put a reverse proxy in front of
+    # it instead of widening this rule.
+    precondition {
+      condition     = length(setintersection(toset(var.ui_public_ports), toset(concat(var.app_ports, [tostring(var.db_port)])))) == 0
+      error_message = "ui_public_ports must not contain any app_ports or db_port: internal application and database ports stay off the public internet."
+    }
+  }
+}
+
 # ssh to private instances only from bastion
 
 resource "google_compute_firewall" "ssh_from_bastion" {
   project     = var.project_id
   name        = "${local.prefix}-allow-ssh-from-bastion"
-  description = "Ingress SSH on port ${var.ssh_port} to private instances, only from instances tagged ${local.tag_bastion}."
+  description = "Ingress SSH on port ${var.ssh_port} to application, database and UI instances, only from instances tagged ${local.tag_bastion}."
 
   network   = google_compute_network.vpc.id
   direction = "INGRESS"
   priority  = 1000
 
   source_tags = [local.tag_bastion]
-  target_tags = [local.tag_app, local.tag_db]
+  target_tags = [local.tag_app, local.tag_db, local.tag_ui]
 
   allow {
     protocol = "tcp"
@@ -141,7 +187,7 @@ resource "google_compute_firewall" "internal_icmp" {
   priority  = 1000
 
   source_ranges = local.internal_ranges
-  target_tags   = [local.tag_bastion, local.tag_app, local.tag_db]
+  target_tags   = [local.tag_bastion, local.tag_app, local.tag_db, local.tag_ui]
 
   allow {
     protocol = "icmp"

--- a/infrastructure/terraform/modules/network/locals.tf
+++ b/infrastructure/terraform/modules/network/locals.tf
@@ -1,0 +1,49 @@
+locals {
+  prefix = var.name_prefix
+
+  # Network tags are the handle firewall rules use to select instances.
+  # Nothing is reachable unless it carries the right tag.
+  tag_bastion = "${local.prefix}-bastion"
+  tag_app     = "${local.prefix}-app"
+  tag_db      = "${local.prefix}-db"
+
+  # "user:public-key" lines, one per person. Empty when OS Login is enabled.
+  ssh_keys_metadata = join("\n", [
+    for user, key in var.ssh_users : "${user}:${trimspace(key)}"
+  ])
+
+  use_metadata_keys = !var.enable_os_login && length(var.ssh_users) > 0
+
+  # Common metadata for every instance in this module.
+  # Built as one map with nulls filtered out, so the type is always map(string).
+  common_metadata = {
+    for k, v in {
+      # Project-wide SSH keys are ignored: access is decided here, not by whoever
+      # happens to have project metadata permissions.
+      block-project-ssh-keys = var.enable_os_login ? "FALSE" : "TRUE"
+      enable-oslogin         = var.enable_os_login ? "TRUE" : "FALSE"
+      serial-port-enable = "FALSE"
+      ssh-keys           = local.use_metadata_keys ? local.ssh_keys_metadata : null
+    } : k => v if v != null
+  }
+
+  startup_script = templatefile("${path.module}/templates/sshd-hardening.sh.tftpl", {
+    ssh_port = var.ssh_port
+  })
+
+  internal_ranges = compact([
+    var.public_subnet_cidr,
+    var.private_subnet_cidr,
+  ])
+
+  firewall_log_config      = var.enable_firewall_logging ? [1] : []
+  firewall_deny_log_config = var.log_denied_traffic ? [1] : []
+
+  labels = merge(
+    {
+      managed-by = "terraform"
+      module     = "network-bastion"
+    },
+    var.labels
+  )
+}

--- a/infrastructure/terraform/modules/network/locals.tf
+++ b/infrastructure/terraform/modules/network/locals.tf
@@ -7,6 +7,11 @@ locals {
   tag_app     = "${local.prefix}-app"
   tag_db      = "${local.prefix}-db"
 
+  # Placeholder contract for the public-facing UI instance, which is created
+  # elsewhere (issue #14). The rule exists now; whoever builds that instance only
+  # has to attach this tag - exported through the network_tags output.
+  tag_ui = "${local.prefix}-ui"
+
   internal_ranges = compact([
     var.public_subnet_cidr,
     var.private_subnet_cidr,

--- a/infrastructure/terraform/modules/network/locals.tf
+++ b/infrastructure/terraform/modules/network/locals.tf
@@ -7,30 +7,6 @@ locals {
   tag_app     = "${local.prefix}-app"
   tag_db      = "${local.prefix}-db"
 
-  # "user:public-key" lines, one per person. Empty when OS Login is enabled.
-  ssh_keys_metadata = join("\n", [
-    for user, key in var.ssh_users : "${user}:${trimspace(key)}"
-  ])
-
-  use_metadata_keys = !var.enable_os_login && length(var.ssh_users) > 0
-
-  # Common metadata for every instance in this module.
-  # Built as one map with nulls filtered out, so the type is always map(string).
-  common_metadata = {
-    for k, v in {
-      # Project-wide SSH keys are ignored: access is decided here, not by whoever
-      # happens to have project metadata permissions.
-      block-project-ssh-keys = var.enable_os_login ? "FALSE" : "TRUE"
-      enable-oslogin         = var.enable_os_login ? "TRUE" : "FALSE"
-      serial-port-enable = "FALSE"
-      ssh-keys           = local.use_metadata_keys ? local.ssh_keys_metadata : null
-    } : k => v if v != null
-  }
-
-  startup_script = templatefile("${path.module}/templates/sshd-hardening.sh.tftpl", {
-    ssh_port = var.ssh_port
-  })
-
   internal_ranges = compact([
     var.public_subnet_cidr,
     var.private_subnet_cidr,
@@ -41,8 +17,8 @@ locals {
 
   labels = merge(
     {
-      managed-by = "terraform"
-      module     = "network-bastion"
+      managed_by = "terraform"
+      module     = "network"
     },
     var.labels
   )

--- a/infrastructure/terraform/modules/network/network.tf
+++ b/infrastructure/terraform/modules/network/network.tf
@@ -1,0 +1,54 @@
+# create vpc
+
+resource "google_compute_network" "vpc" {
+  project     = var.project_id
+  name        = "${local.prefix}-vpc"
+  description = "Custom-mode VPC for ${local.prefix}: public bastion subnet + private workload subnet."
+
+  auto_create_subnetworks = false
+  routing_mode            = var.routing_mode
+  mtu                     = var.mtu
+
+  # See routing.tf: when true the implicit default route is dropped and replaced
+  # by an explicitly managed one.
+  delete_default_routes_on_create = var.manage_default_route
+}
+
+# create subnets
+
+resource "google_compute_subnetwork" "public" {
+  project     = var.project_id
+  name        = "${local.prefix}-subnet-public"
+  description = "Public subnet: bastion host only."
+
+  region        = var.region
+  network       = google_compute_network.vpc.id
+  ip_cidr_range = var.public_subnet_cidr
+
+  # Not needed here (the bastion has a public IP and a route to the internet),
+  # but harmless and keeps behaviour identical if the external IP is ever removed.
+  private_ip_google_access = true
+}
+
+resource "google_compute_subnetwork" "private" {
+  project     = var.project_id
+  name        = "${local.prefix}-subnet-private"
+  description = "Private subnet: application and database instances, no external IPs."
+
+  region        = var.region
+  network       = google_compute_network.vpc.id
+  ip_cidr_range = var.private_subnet_cidr
+
+  # Lets instances without an external IP reach Google APIs (Artifact Registry,
+  # Cloud Logging, Secret Manager, ...) over internal IPs instead of via NAT.
+  private_ip_google_access = true
+
+  dynamic "secondary_ip_range" {
+    for_each = var.private_secondary_ranges
+
+    content {
+      range_name    = secondary_ip_range.key
+      ip_cidr_range = secondary_ip_range.value
+    }
+  }
+}

--- a/infrastructure/terraform/modules/network/network.tf
+++ b/infrastructure/terraform/modules/network/network.tf
@@ -3,7 +3,7 @@
 resource "google_compute_network" "vpc" {
   project     = var.project_id
   name        = "${local.prefix}-vpc"
-  description = "Custom-mode VPC for ${local.prefix}: public bastion subnet + private workload subnet."
+  description = "Custom-mode VPC for ${local.prefix}: public subnet (bastion, UI) + private workload subnet."
 
   auto_create_subnetworks = false
   routing_mode            = var.routing_mode
@@ -19,14 +19,14 @@ resource "google_compute_network" "vpc" {
 resource "google_compute_subnetwork" "public" {
   project     = var.project_id
   name        = "${local.prefix}-subnet-public"
-  description = "Public subnet: bastion host only."
+  description = "Public subnet: bastion host and the public-facing UI instance."
 
   region        = var.region
   network       = google_compute_network.vpc.id
   ip_cidr_range = var.public_subnet_cidr
 
-  # Not needed here (the bastion has a public IP and a route to the internet),
-  # but harmless and keeps behaviour identical if the external IP is ever removed.
+  # Not needed while these instances have public IPs and a route to the internet,
+  # but harmless and keeps behaviour identical if an external IP is ever removed.
   private_ip_google_access = true
 }
 

--- a/infrastructure/terraform/modules/network/outputs.tf
+++ b/infrastructure/terraform/modules/network/outputs.tf
@@ -63,3 +63,38 @@ output "firewall_rules" {
     google_compute_firewall.deny_all_ingress.name,
   ])
 }
+output "egress_firewall_rules" {
+  description = "Names of the egress rules. Empty when restrict_egress is false and the permissive implied egress rule applies."
+  value = compact(concat(
+    google_compute_firewall.egress_internal[*].name,
+    google_compute_firewall.egress_metadata_server[*].name,
+    google_compute_firewall.egress_dns_ntp[*].name,
+    google_compute_firewall.egress_internet[*].name,
+    google_compute_firewall.deny_all_egress[*].name,
+  ))
+}
+
+output "default_route_name" {
+  description = "Name of the explicitly managed default route, or null when the auto-created route is kept."
+  value       = var.manage_default_route ? google_compute_route.default_internet[0].name : null
+}
+
+output "ssh_port" {
+  description = "Non-default SSH port opened by the firewall rules. The bastion module must configure sshd on the same port."
+  value       = var.ssh_port
+}
+
+output "bastion_allowed_cidrs" {
+  description = "Source ranges currently allowed to reach the bastion on ssh_port."
+  value       = var.bastion_allowed_cidrs
+}
+
+output "app_ports" {
+  description = "Application ports reachable from inside the VPC only."
+  value       = var.app_ports
+}
+
+output "db_port" {
+  description = "Database port, reachable only from instances tagged as application servers."
+  value       = var.db_port
+}

--- a/infrastructure/terraform/modules/network/outputs.tf
+++ b/infrastructure/terraform/modules/network/outputs.tf
@@ -1,0 +1,65 @@
+output "network_name" {
+  description = "Name of the VPC network."
+  value       = google_compute_network.vpc.name
+}
+
+output "network_id" {
+  description = "Fully qualified ID of the VPC network, for use by other modules."
+  value       = google_compute_network.vpc.id
+}
+
+output "network_self_link" {
+  description = "Self link of the VPC network."
+  value       = google_compute_network.vpc.self_link
+}
+
+output "public_subnet" {
+  description = "Public (bastion) subnet: name, id and CIDR."
+  value = {
+    name = google_compute_subnetwork.public.name
+    id   = google_compute_subnetwork.public.id
+    cidr = google_compute_subnetwork.public.ip_cidr_range
+  }
+}
+
+output "private_subnet" {
+  description = "Private (workload) subnet: name, id, CIDR and secondary ranges."
+  value = {
+    name             = google_compute_subnetwork.private.name
+    id               = google_compute_subnetwork.private.id
+    cidr             = google_compute_subnetwork.private.ip_cidr_range
+    secondary_ranges = var.private_secondary_ranges
+    google_access    = google_compute_subnetwork.private.private_ip_google_access
+  }
+}
+
+output "network_tags" {
+  description = "Network tags an instance must carry to be matched by the firewall rules."
+  value = {
+    bastion = local.tag_bastion
+    app     = local.tag_app
+    db      = local.tag_db
+  }
+}
+
+output "nat_name" {
+  description = "Name of the Cloud NAT gateway, or null when NAT is disabled."
+  value       = var.enable_nat ? google_compute_router_nat.nat[0].name : null
+}
+
+output "nat_egress_ips" {
+  description = "Static egress IPs used by Cloud NAT. Empty when NAT allocates addresses automatically - share these for partner IP allow-listing."
+  value       = google_compute_address.nat[*].address
+}
+
+output "firewall_rules" {
+  description = "Names of every firewall rule created, in priority order. Handy for `gcloud compute firewall-rules describe`."
+  value = compact([
+    google_compute_firewall.bastion_ssh_ingress.name,
+    google_compute_firewall.ssh_from_bastion.name,
+    google_compute_firewall.app_internal.name,
+    google_compute_firewall.db_from_app.name,
+    google_compute_firewall.internal_icmp.name,
+    google_compute_firewall.deny_all_ingress.name,
+  ])
+}

--- a/infrastructure/terraform/modules/network/outputs.tf
+++ b/infrastructure/terraform/modules/network/outputs.tf
@@ -39,6 +39,7 @@ output "network_tags" {
     bastion = local.tag_bastion
     app     = local.tag_app
     db      = local.tag_db
+    ui      = local.tag_ui
   }
 }
 
@@ -54,14 +55,16 @@ output "nat_egress_ips" {
 
 output "firewall_rules" {
   description = "Names of every firewall rule created, in priority order. Handy for `gcloud compute firewall-rules describe`."
-  value = compact([
+  value = compact(concat([
     google_compute_firewall.bastion_ssh_ingress.name,
     google_compute_firewall.ssh_from_bastion.name,
     google_compute_firewall.app_internal.name,
     google_compute_firewall.db_from_app.name,
     google_compute_firewall.internal_icmp.name,
     google_compute_firewall.deny_all_ingress.name,
-  ])
+    ],
+    google_compute_firewall.ui_public_ingress[*].name,
+  ))
 }
 output "egress_firewall_rules" {
   description = "Names of the egress rules. Empty when restrict_egress is false and the permissive implied egress rule applies."
@@ -87,6 +90,11 @@ output "ssh_port" {
 output "bastion_allowed_cidrs" {
   description = "Source ranges currently allowed to reach the bastion on ssh_port."
   value       = var.bastion_allowed_cidrs
+}
+
+output "ui_public_ports" {
+  description = "Ports published to the internet for instances carrying the ui tag. Empty when the public UI rule is disabled."
+  value       = var.enable_ui_public_ingress ? var.ui_public_ports : []
 }
 
 output "app_ports" {

--- a/infrastructure/terraform/modules/network/routing.tf
+++ b/infrastructure/terraform/modules/network/routing.tf
@@ -1,0 +1,61 @@
+resource "google_compute_route" "default_internet" {
+  count = var.manage_default_route ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-rt-default-internet"
+  description = "Explicitly managed default route. Replaces the auto-created one so routing is visible in the plan."
+
+  network          = google_compute_network.vpc.id
+  dest_range       = "0.0.0.0/0"
+  next_hop_gateway = "default-internet-gateway"
+  priority         = 1000
+}
+
+# Cloud NAT for private subnet
+
+resource "google_compute_router" "router" {
+  count = var.enable_nat ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.prefix}-router"
+  description = "Cloud Router hosting the NAT gateway for the private subnet."
+  region      = var.region
+  network     = google_compute_network.vpc.id
+}
+
+resource "google_compute_address" "nat" {
+  count = var.enable_nat ? var.nat_static_ip_count : 0
+
+  project      = var.project_id
+  name         = "${local.prefix}-nat-ip-${count.index + 1}"
+  description  = "Static egress IP for Cloud NAT - hand this to partners that require IP allow-listing."
+  region       = var.region
+  address_type = "EXTERNAL"
+  labels       = local.labels
+}
+
+resource "google_compute_router_nat" "nat" {
+  count = var.enable_nat ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.prefix}-nat"
+  router  = google_compute_router.router[0].name
+  region  = var.region
+
+  nat_ip_allocate_option = var.nat_static_ip_count > 0 ? "MANUAL_ONLY" : "AUTO_ONLY"
+  nat_ips                = var.nat_static_ip_count > 0 ? google_compute_address.nat[*].self_link : null
+
+  # Only the private subnet is NATed. The bastion uses its own external IP,
+  # so it never consumes NAT ports.
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.private.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  log_config {
+    enable = true
+    filter = var.nat_log_filter
+  }
+}

--- a/infrastructure/terraform/modules/network/variables.tf
+++ b/infrastructure/terraform/modules/network/variables.tf
@@ -11,12 +11,6 @@ variable "region" {
   default     = "europe-central2"
 }
 
-variable "zone" {
-  description = "Zone for the bastion host (and the optional example workloads)."
-  type        = string
-  default     = "europe-central2-a"
-}
-
 variable "name_prefix" {
   description = "Prefix for every resource name. Keep it short: GCP names are limited to 63 chars."
   type        = string
@@ -132,7 +126,7 @@ variable "nat_log_filter" {
 # variables for ssh access
 
 variable "ssh_port" {
-  description = "Non-default SSH port. Used both in the firewall rule and in the sshd configuration."
+  description = "Non-default SSH port. Used both in the firewall rules here and in the sshd configuration of the bastion module."
   type        = number
   default     = 18832
 
@@ -170,69 +164,12 @@ variable "bastion_allowed_cidrs" {
   }
 }
 
-variable "ssh_users" {
-  description = <<-EOT
-    One public SSH key per person, keyed by the Linux username.
-    Values are PUBLIC keys only (ssh-ed25519 / ssh-rsa / ecdsa-* / sk-*).
-    Private keys are never accepted, never generated and never stored by this module.
-
-    Example:
-      ssh_users = {
-        tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... tabula@laptop"
-        rasa  = file("~/keys/rasa.pub")
-      }
-  EOT
-  type        = map(string)
-  default     = {}
-
-  validation {
-    condition = alltrue([
-      for u in keys(var.ssh_users) : can(regex("^[a-z_][a-z0-9_-]{0,31}$", u))
-    ])
-    error_message = "Every ssh_users key must be a valid POSIX username (lowercase, starts with a letter or underscore, max 32 chars)."
-  }
-
-  validation {
-    condition = alltrue([
-      for k in values(var.ssh_users) :
-      can(regex("^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)|sk-ssh-ed25519@openssh\\.com|sk-ecdsa-sha2-nistp256@openssh\\.com) AAAA[0-9A-Za-z+/=]+", trimspace(k)))
-    ])
-    error_message = "Every ssh_users value must be a single OpenSSH PUBLIC key line starting with a supported key type."
-  }
-
-  validation {
-    condition = alltrue([
-      for k in values(var.ssh_users) :
-      !can(regex("(?i)PRIVATE KEY", k))
-    ])
-    error_message = "A PRIVATE key was passed to ssh_users. Private keys must never enter Terraform code or state - pass the .pub file only."
-  }
-
-  validation {
-    condition = alltrue([
-      for k in values(var.ssh_users) : length(split("\n", trimspace(k))) == 1
-    ])
-    error_message = "Exactly one public key per person is supported: each ssh_users value must be a single line."
-  }
-}
-
-variable "enable_os_login" {
-  description = <<-EOT
-    Use OS Login instead of instance metadata keys. When true, ssh_users is ignored and
-    access is granted through IAM (roles/compute.osLogin + roles/iap.tunnelResourceAccessor),
-    which gives central revocation and audit logs. Set to false to use the per-person
-    metadata keys from ssh_users.
-  EOT
-  type        = bool
-  default     = false
-}
-
 # variables related to application / db ports
 
 variable "app_ports" {
-  description = "Internal application ports, reachable only from inside the VPC and from Google load balancer health checks."
+  description = "Internal application ports, reachable only from inside the VPC. Never from the internet."
   type        = list(string)
-  default     = ["8080","5672","6379","15672"]
+  default     = ["8080", "5672", "6379", "15672"]
 
   validation {
     condition     = length(var.app_ports) > 0
@@ -244,12 +181,6 @@ variable "db_port" {
   description = "Database port. Reachable only from instances carrying the application tag."
   type        = number
   default     = 5432
-}
-
-variable "enable_lb_health_checks" {
-  description = "Allow Google's load balancer / health check probe ranges (35.191.0.0/16, 130.211.0.0/22) to reach app_ports."
-  type        = bool
-  default     = true
 }
 
 # variables related to firewall behavior
@@ -269,8 +200,9 @@ variable "log_denied_traffic" {
 variable "restrict_egress" {
   description = <<-EOT
     When true, the permissive implied egress rule is overridden by a deny-all egress rule plus
-    narrow allows (DNS, NTP, HTTPS, in-VPC traffic). Genuine least privilege, but it will break
-    anything that talks to an unexpected endpoint - roll it out in a non-production project first.
+    narrow allows (DNS, NTP, the metadata server, egress_allowed_ports and in-VPC traffic).
+    Genuine least privilege, but it will break anything that talks to an unexpected endpoint -
+    roll it out in a non-production project first.
   EOT
   type        = bool
   default     = false
@@ -280,4 +212,9 @@ variable "egress_allowed_ports" {
   description = "TCP ports allowed outbound to the internet when restrict_egress is true."
   type        = list(string)
   default     = ["443"]
+
+  validation {
+    condition     = !var.restrict_egress || length(var.egress_allowed_ports) > 0
+    error_message = "egress_allowed_ports must not be empty when restrict_egress is true."
+  }
 }

--- a/infrastructure/terraform/modules/network/variables.tf
+++ b/infrastructure/terraform/modules/network/variables.tf
@@ -31,7 +31,7 @@ variable "labels" {
 # variables related to network and subnets
 
 variable "public_subnet_cidr" {
-  description = "CIDR of the public subnet. Only the bastion lives here."
+  description = "CIDR of the public subnet. The bastion and the public-facing UI instance live here."
   type        = string
   default     = "10.10.0.0/24"
 
@@ -181,6 +181,43 @@ variable "db_port" {
   description = "Database port. Reachable only from instances carrying the application tag."
   type        = number
   default     = 5432
+}
+
+variable "enable_ui_public_ingress" {
+  description = "Create the public HTTP/HTTPS ingress rule for instances tagged <name_prefix>-ui."
+  type        = bool
+  default     = true
+}
+
+variable "ui_public_ports" {
+  description = <<-EOT
+    TCP ports the UI service exposes to the internet. 80 is kept so the UI can
+    redirect to HTTPS and so ACME HTTP-01 challenges work.
+    Application and database ports must never appear here.
+  EOT
+  type        = list(string)
+  default     = ["80", "443"]
+
+  validation {
+    condition     = !var.enable_ui_public_ingress || length(var.ui_public_ports) > 0
+    error_message = "ui_public_ports must not be empty when enable_ui_public_ingress is true."
+  }
+}
+
+variable "ui_source_ranges" {
+  description = <<-EOT
+    Source ranges allowed to reach ui_public_ports. 0.0.0.0/0 on purpose: this is
+    the public web entry point. Narrow it while the UI is not meant to be public yet.
+  EOT
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+
+  validation {
+    condition = alltrue([
+      for c in var.ui_source_ranges : can(cidrhost(c, 0))
+    ])
+    error_message = "Every entry in ui_source_ranges must be a valid IPv4 CIDR block."
+  }
 }
 
 # variables related to firewall behavior

--- a/infrastructure/terraform/modules/network/variables.tf
+++ b/infrastructure/terraform/modules/network/variables.tf
@@ -1,0 +1,283 @@
+# variables related to project and naming
+
+variable "project_id" {
+  description = "GCP project ID where all resources are created."
+  type        = string
+}
+
+variable "region" {
+  description = "Primary region for the subnets, Cloud Router and Cloud NAT."
+  type        = string
+  default     = "europe-central2"
+}
+
+variable "zone" {
+  description = "Zone for the bastion host (and the optional example workloads)."
+  type        = string
+  default     = "europe-central2-a"
+}
+
+variable "name_prefix" {
+  description = "Prefix for every resource name. Keep it short: GCP names are limited to 63 chars."
+  type        = string
+  default     = "oil"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name_prefix))
+    error_message = "name_prefix must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "labels" {
+  description = "Labels applied to every resource that supports them."
+  type        = map(string)
+  default     = {}
+}
+
+# variables related to network and subnets
+
+variable "public_subnet_cidr" {
+  description = "CIDR of the public subnet. Only the bastion lives here."
+  type        = string
+  default     = "10.10.0.0/24"
+
+  validation {
+    condition     = can(cidrhost(var.public_subnet_cidr, 0))
+    error_message = "public_subnet_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "private_subnet_cidr" {
+  description = "CIDR of the private subnet. Application and database instances live here and never get an external IP."
+  type        = string
+  default     = "10.10.1.0/24"
+
+  validation {
+    condition     = can(cidrhost(var.private_subnet_cidr, 0))
+    error_message = "private_subnet_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "private_secondary_ranges" {
+  description = <<-EOT
+    Optional secondary ranges on the private subnet (e.g. GKE pods/services).
+    Example: { pods = "10.20.0.0/16", services = "10.21.0.0/20" }
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
+variable "routing_mode" {
+  description = "VPC dynamic routing mode: REGIONAL or GLOBAL."
+  type        = string
+  default     = "REGIONAL"
+
+  validation {
+    condition     = contains(["REGIONAL", "GLOBAL"], var.routing_mode)
+    error_message = "routing_mode must be REGIONAL or GLOBAL."
+  }
+}
+
+variable "mtu" {
+  description = "VPC MTU. 1460 is the GCP default"
+  type        = number
+  default     = 1460
+}
+
+variable "manage_default_route" {
+  description = <<-EOT
+    When true, the auto-created default route is deleted at network creation time and
+    replaced by an explicitly managed 0.0.0.0/0 -> default-internet-gateway route.
+    Routing then lives entirely in code and shows up in the plan. Egress is still
+    controlled by firewall rules, not by this route.
+  EOT
+  type        = bool
+  default     = true
+}
+
+# variables for cloud nat
+
+variable "enable_nat" {
+  description = "Create Cloud Router + Cloud NAT so private instances get egress-only internet access."
+  type        = bool
+  default     = true
+}
+
+variable "nat_static_ip_count" {
+  description = <<-EOT
+    Number of static external IPs to reserve for Cloud NAT.
+    0 = AUTO_ONLY (Google picks ephemeral IPs).
+    >0 = MANUAL_ONLY, which gives you a stable egress IP set you can hand to third parties for allow-listing.
+  EOT
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.nat_static_ip_count >= 0 && var.nat_static_ip_count <= 8
+    error_message = "nat_static_ip_count must be between 0 and 8."
+  }
+}
+
+variable "nat_log_filter" {
+  description = "Cloud NAT logging filter: ERRORS_ONLY, TRANSLATIONS_ONLY or ALL."
+  type        = string
+  default     = "ERRORS_ONLY"
+
+  validation {
+    condition     = contains(["ERRORS_ONLY", "TRANSLATIONS_ONLY", "ALL"], var.nat_log_filter)
+    error_message = "nat_log_filter must be ERRORS_ONLY, TRANSLATIONS_ONLY or ALL."
+  }
+}
+
+# variables for ssh access
+
+variable "ssh_port" {
+  description = "Non-default SSH port. Used both in the firewall rule and in the sshd configuration."
+  type        = number
+  default     = 18832
+
+  validation {
+    condition     = var.ssh_port >= 1024 && var.ssh_port <= 65535 && var.ssh_port != 22
+    error_message = "ssh_port must be in the 1024-65535 range and must not be the default port 22."
+  }
+}
+
+variable "bastion_allowed_cidrs" {
+  description = <<-EOT
+    Source CIDRs allowed to reach the bastion on ssh_port. Office ranges / VPN egress IPs only.
+    Unrestricted access (0.0.0.0/0, ::/0, or anything broader than /8) is rejected.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.bastion_allowed_cidrs) > 0
+    error_message = "bastion_allowed_cidrs must contain at least one CIDR: the bastion is useless without an allowed source."
+  }
+
+  validation {
+    condition = alltrue([
+      for c in var.bastion_allowed_cidrs : can(cidrhost(c, 0))
+    ])
+    error_message = "Every entry in bastion_allowed_cidrs must be a valid IPv4 CIDR block (e.g. 203.0.113.10/32)."
+  }
+
+  validation {
+    condition = alltrue([
+      for c in var.bastion_allowed_cidrs :
+      !contains(["0.0.0.0/0", "::/0"], trimspace(c)) && try(tonumber(split("/", c)[1]) >= 8, false)
+    ])
+    error_message = "Unrestricted public SSH is not allowed: remove 0.0.0.0/0 (and any prefix shorter than /8) from bastion_allowed_cidrs."
+  }
+}
+
+variable "ssh_users" {
+  description = <<-EOT
+    One public SSH key per person, keyed by the Linux username.
+    Values are PUBLIC keys only (ssh-ed25519 / ssh-rsa / ecdsa-* / sk-*).
+    Private keys are never accepted, never generated and never stored by this module.
+
+    Example:
+      ssh_users = {
+        tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... tabula@laptop"
+        rasa  = file("~/keys/rasa.pub")
+      }
+  EOT
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for u in keys(var.ssh_users) : can(regex("^[a-z_][a-z0-9_-]{0,31}$", u))
+    ])
+    error_message = "Every ssh_users key must be a valid POSIX username (lowercase, starts with a letter or underscore, max 32 chars)."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) :
+      can(regex("^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)|sk-ssh-ed25519@openssh\\.com|sk-ecdsa-sha2-nistp256@openssh\\.com) AAAA[0-9A-Za-z+/=]+", trimspace(k)))
+    ])
+    error_message = "Every ssh_users value must be a single OpenSSH PUBLIC key line starting with a supported key type."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) :
+      !can(regex("(?i)PRIVATE KEY", k))
+    ])
+    error_message = "A PRIVATE key was passed to ssh_users. Private keys must never enter Terraform code or state - pass the .pub file only."
+  }
+
+  validation {
+    condition = alltrue([
+      for k in values(var.ssh_users) : length(split("\n", trimspace(k))) == 1
+    ])
+    error_message = "Exactly one public key per person is supported: each ssh_users value must be a single line."
+  }
+}
+
+variable "enable_os_login" {
+  description = <<-EOT
+    Use OS Login instead of instance metadata keys. When true, ssh_users is ignored and
+    access is granted through IAM (roles/compute.osLogin + roles/iap.tunnelResourceAccessor),
+    which gives central revocation and audit logs. Set to false to use the per-person
+    metadata keys from ssh_users.
+  EOT
+  type        = bool
+  default     = false
+}
+
+# variables related to application / db ports
+
+variable "app_ports" {
+  description = "Internal application ports, reachable only from inside the VPC and from Google load balancer health checks."
+  type        = list(string)
+  default     = ["8080","5672","6379","15672"]
+
+  validation {
+    condition     = length(var.app_ports) > 0
+    error_message = "app_ports must not be empty."
+  }
+}
+
+variable "db_port" {
+  description = "Database port. Reachable only from instances carrying the application tag."
+  type        = number
+  default     = 5432
+}
+
+variable "enable_lb_health_checks" {
+  description = "Allow Google's load balancer / health check probe ranges (35.191.0.0/16, 130.211.0.0/22) to reach app_ports."
+  type        = bool
+  default     = true
+}
+
+# variables related to firewall behavior
+
+variable "enable_firewall_logging" {
+  description = "Enable firewall rule logging on the allow rules. Strongly recommended: this is what proves who connected."
+  type        = bool
+  default     = true
+}
+
+variable "log_denied_traffic" {
+  description = "Also log the explicit low-priority deny rules. Very useful while debugging, noisy and costly in steady state."
+  type        = bool
+  default     = false
+}
+
+variable "restrict_egress" {
+  description = <<-EOT
+    When true, the permissive implied egress rule is overridden by a deny-all egress rule plus
+    narrow allows (DNS, NTP, HTTPS, in-VPC traffic). Genuine least privilege, but it will break
+    anything that talks to an unexpected endpoint - roll it out in a non-production project first.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "egress_allowed_ports" {
+  description = "TCP ports allowed outbound to the internet when restrict_egress is true."
+  type        = list(string)
+  default     = ["443"]
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,88 @@
+# network
+
+output "network_name" {
+  description = "Name of the VPC network."
+  value       = module.network.network_name
+}
+
+output "network_self_link" {
+  description = "Self link of the VPC network."
+  value       = module.network.network_self_link
+}
+
+output "public_subnet" {
+  description = "Public (bastion) subnet: name, id and CIDR."
+  value       = module.network.public_subnet
+}
+
+output "private_subnet" {
+  description = "Private (workload) subnet: name, id, CIDR and secondary ranges."
+  value       = module.network.private_subnet
+}
+
+output "network_tags" {
+  description = "Network tags an instance must carry to be matched by the firewall rules."
+  value       = module.network.network_tags
+}
+
+output "firewall_rules" {
+  description = "Ingress firewall rules created for this VPC."
+  value       = module.network.firewall_rules
+}
+
+output "egress_firewall_rules" {
+  description = "Egress firewall rules. Empty unless restrict_egress is enabled."
+  value       = module.network.egress_firewall_rules
+}
+
+output "nat_name" {
+  description = "Name of the Cloud NAT gateway that gives private instances outbound access."
+  value       = module.network.nat_name
+}
+
+output "nat_egress_ips" {
+  description = "Static egress IPs used by Cloud NAT. Empty when NAT allocates addresses automatically."
+  value       = module.network.nat_egress_ips
+}
+
+# bastion
+
+output "bastion_name" {
+  description = "Name of the bastion instance."
+  value       = module.bastion.bastion_name
+}
+
+output "bastion_public_ip" {
+  description = "Static external IP of the bastion: the single entry point into the VPC."
+  value       = module.bastion.bastion_public_ip
+}
+
+output "bastion_private_ip" {
+  description = "Internal IP of the bastion inside the VPC."
+  value       = module.bastion.bastion_private_ip
+}
+
+output "bastion_service_account" {
+  description = "Email of the dedicated bastion service account."
+  value       = module.bastion.bastion_service_account
+}
+
+output "ssh_port" {
+  description = "Team-approved non-default SSH port. Port 22 is closed everywhere."
+  value       = var.ssh_port
+}
+
+output "ssh_users" {
+  description = "Usernames with a public key installed on the bastion."
+  value       = module.bastion.ssh_users
+}
+
+output "bastion_ssh_command" {
+  description = "Ready-to-run SSH command for the bastion. Replace <user> with your own username."
+  value       = module.bastion.bastion_ssh_command
+}
+
+output "bastion_proxy_jump_command" {
+  description = "Template for reaching a private instance through the bastion with ProxyJump."
+  value       = module.bastion.bastion_proxy_jump_command
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -25,6 +25,11 @@ output "network_tags" {
   value       = module.network.network_tags
 }
 
+output "ui_public_ports" {
+  description = "Ports published to the internet for instances carrying the ui network tag."
+  value       = module.network.ui_public_ports
+}
+
 output "firewall_rules" {
   description = "Ingress firewall rules created for this VPC."
   value       = module.network.firewall_rules

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -8,3 +8,24 @@ common_labels = {
   project = "oil-price-tracker"
   team    = "ua-academy"
 }
+
+# Non-default SSH port. Port 22 is closed everywhere.
+ssh_port = 18832
+
+# Who may reach the bastion at all. Office / VPN egress addresses only.
+# 0.0.0.0/0 (and anything broader than /8) is rejected by variable validation.
+bastion_allowed_cidrs = [
+  "203.0.113.10/32",
+  "198.51.100.0/28",
+]
+
+# One PUBLIC key per person, keyed by the Linux username.
+# Never put a private key here: this file feeds Terraform state.
+ssh_users = {
+  tabula = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexampleexampleexampleexampleexample tabula@laptop"
+  rasa   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIanotherkeyanotherkeyanotherkeyanoth rasa@laptop"
+}
+
+# Subnet CIDRs, application/database ports, NAT and egress restriction come from
+# the defaults in modules/network/variables.tf. Override them in main.tf if the
+# defaults ever stop fitting.

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -57,3 +57,27 @@ variable "common_labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "ssh_port" {
+  description = "Team-approved non-default SSH port. Used by the firewall rules and by sshd on the bastion."
+  type        = number
+  default     = 18832
+
+  validation {
+    condition     = var.ssh_port >= 1024 && var.ssh_port <= 65535 && var.ssh_port != 22
+    error_message = "ssh_port must be in the 1024-65535 range and must not be the default port 22."
+  }
+}
+
+variable "bastion_allowed_cidrs" {
+  description = "Source CIDRs allowed to reach the bastion on ssh_port. Office ranges / VPN egress IPs only, never 0.0.0.0/0."
+  type        = list(string)
+}
+
+variable "ssh_users" {
+  description = <<-EOT
+    One PUBLIC SSH key per person, keyed by the Linux username.
+    Private keys are never generated, accepted or stored by this configuration.
+  EOT
+  type        = map(string)
+}


### PR DESCRIPTION
Closes #13 

## Network and bastion infrastructure provision with Terraform (#13)

Adds the Terraform network layer and the SSH entry point into the VPC.

**Network** (`modules/network`)
- Custom-mode VPC with a public subnet (bastion, UI) and a private subnet (app, database).
- Explicitly managed default route + Cloud Router/NAT, so private instances get egress-only internet access.
- Least-privilege firewall: SSH to the bastion from approved CIDRs only, SSH to private instances only from the bastion, app ports internal-only, database port reachable only from instances tagged `<prefix>-app`, catch-all ingress deny. Optional deny-all egress behind `restrict_egress`.
- Public HTTP/HTTPS ingress for the UI service, targeted by the `<prefix>-ui` tag so the instance can be created separately. A precondition fails the plan if that rule ever overlaps an app or database port.

**Bastion** (`modules/bastion`)
- Hardened Shielded VM with a static IP, dedicated service account and logging roles.
- sshd moved to the team-approved non-default port (22 is closed), key-only auth, root login and passwords disabled.
- One public SSH key per person via `ssh_users`; project-wide keys blocked. No private key is ever generated or stored by Terraform.
- `0.0.0.0/0` in `bastion_allowed_cidrs` is rejected by variable validation and a resource precondition.

**Docs & outputs**
- `README.md` per module: access procedure, revocation, and how to verify access.
- Network and bastion outputs, including ready-to-run SSH / ProxyJump commands.

**Checks:** `terraform fmt -check -recursive` and `terraform validate` pass for the root module and both modules; `terraform plan` produces 18 resources.