### PR TITLE
Provision Secret Manager containers and version-write access

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,189 @@
+# Secrets
+
+Runtime secrets live in Google Secret Manager. Terraform creates the secret
+containers and the access policy around them; it never creates a secret
+*version*. No secret value is passed to Terraform, written into Terraform
+state, or committed to this repository.
+
+## What Terraform owns
+
+| Terraform owns | Terraform does not own |
+| --- | --- |
+| The `secretmanager.googleapis.com` API being enabled | Any secret value |
+| The secret containers, their replication and labels | Any secret version |
+| Read access (`roles/secretmanager.secretAccessor`) per secret, per VM | The upstream credential itself (the key at the provider, the PostgreSQL role) |
+| Write access (`roles/secretmanager.secretVersionAdder`) for named principals | Delivering values into the running containers |
+
+`google_secret_manager_secret_version` is deliberately absent from the
+configuration. A version resource would mean the payload arrives as Terraform
+input and ends up in plaintext in `terraform.tfstate`, which is exactly what
+this design avoids.
+
+## Where the access map comes from
+
+Nothing about access is hard-coded in Terraform. Both the list of secrets and
+who may read them are derived from the project JSON:
+
+```json
+{
+  "vms": [
+    {
+      "name": "ui",
+      "role": "ui",
+      "secret_ids": ["oilscope-dev-db-password-ui"]
+    }
+  ]
+}
+```
+
+- **Which secrets exist**: the union of every `secret_ids` entry across all
+  VMs. A secret nothing reads is never created; a secret a VM asks for is
+  always created.
+- **Who may read a secret**: exactly the service accounts of the VMs that list
+  it. The grant is made on that one secret, never at project scope.
+
+Because the containers and the grants come from the same field, the two cannot
+drift apart. Listing a secret ID that does not exist elsewhere in the file is
+not a silent misconfiguration — Terraform creates it.
+
+To see the resulting map without opening the console:
+
+```bash
+terraform output secret_access_map
+```
+
+and to confirm the live policy matches what Terraform believes:
+
+```bash
+gcloud secrets get-iam-policy oilscope-dev-db-password-ui --project PROJECT_ID
+```
+
+## Granting access
+
+Add the secret ID to that VM's `secret_ids` in the project JSON and apply:
+
+```bash
+terraform plan -var="project_config_path=/absolute/path/to/dev.json" -out=tfplan
+terraform apply tfplan
+```
+
+## Revoking access
+
+Remove the secret ID from that VM's `secret_ids` and apply. Terraform destroys
+the corresponding `google_secret_manager_secret_iam_member`, and the VM's
+service account loses `secretAccessor` on that secret only — every other grant
+is untouched, because each one is a separate resource.
+
+Two things to know:
+
+- **Revocation is not retroactive.** If the VM has already read the value, it
+  still has it, and a running process keeps whatever it loaded at start. When
+  you revoke because of a suspected compromise, rotate the credential too.
+- **Effect is not instant.** IAM changes propagate within about two minutes,
+  occasionally longer. Do not conclude the change failed from a single
+  immediate retry.
+
+To take a secret out of service entirely, remove it from every VM's
+`secret_ids`. The container is then no longer in the union and Terraform
+destroys it, along with every version inside it — there is no undo.
+
+## Storing a value
+
+Only principals listed in the `secret_version_managers` Terraform input can do
+this. `roles/secretmanager.secretVersionAdder` allows adding a new version and
+nothing else — it does not allow reading existing payloads.
+
+Generate a database password and store it without the value reaching your shell
+history or the filesystem:
+
+```bash
+printf '%s' "$(openssl rand -hex 32)" \
+  | gcloud secrets versions add oilscope-dev-db-password-ui \
+      --project PROJECT_ID --data-file=-
+```
+
+`-hex` rather than `-base64`: the password ends up inside a `postgres://` URL,
+and base64 output contains `+` and `/`, which change what that URL means.
+
+Store a value you were given, such as an API key:
+
+```bash
+read -rs -p "OilPriceAPI key: " VALUE && echo
+printf '%s' "${VALUE}" \
+  | gcloud secrets versions add oilscope-dev-oilpriceapi-key \
+      --project PROJECT_ID --data-file=-
+unset VALUE
+```
+
+`read -rs` keeps the value off the terminal and out of shell history;
+`printf '%s'` avoids a trailing newline that would silently become part of the
+password. Never `echo "the-value" | ...` with the value typed inline, and do
+not use `--data-file=some-file` unless you delete the file afterwards.
+
+## Reading a value at runtime
+
+The workload VMs run with the `cloud-platform` OAuth scope and their own
+service account, so nothing further needs configuring:
+
+```bash
+gcloud secrets versions access latest \
+  --secret=oilscope-dev-db-password-ui --project PROJECT_ID
+```
+
+Values are fetched when a service starts, not baked into an image or a file.
+Whatever performs the injection must pass them through the **process
+environment only**: no `.env` file on disk, no secret on a command line, no
+secret in a Compose file committed here.
+
+A VM asking for a secret that is not in its `secret_ids` gets
+`PERMISSION_DENIED`. That is the intended way to verify the map is real rather
+than decorative — try to read another role's secret from the `ui` VM and
+confirm it fails.
+
+The mechanism that loads these into the running containers is not part of this
+configuration. Terraform provides the storage and the boundary; delivery is
+handled separately.
+
+## Rotation
+
+1. Add a new version with the commands above. `latest` immediately points at it.
+2. Apply the new value upstream — regenerate the key at the provider, or
+   `ALTER ROLE ... WITH PASSWORD ...` in PostgreSQL.
+3. Restart the consuming service so it picks the new value up. A running
+   process keeps the value it read at start; adding a version changes nothing
+   on its own.
+4. Only then retire the old version:
+
+```bash
+gcloud secrets versions disable 3 --secret=oilscope-dev-db-password-ui --project PROJECT_ID
+# after confirming nothing broke
+gcloud secrets versions destroy 3 --secret=oilscope-dev-db-password-ui --project PROJECT_ID
+```
+
+Disable first, destroy later: a disabled version can be re-enabled if something
+was still using it, a destroyed one cannot.
+
+## If a secret leaks
+
+A value that has appeared in a repository, a build log, a screenshot or a chat
+is compromised, whether or not anyone can prove it was read. Deleting the
+commit does not undo it.
+
+1. **Invalidate the credential at its source first.** Regenerate the key at the
+   provider; change the PostgreSQL role's password. Until this is done, nothing
+   you do in Secret Manager matters — the leaked string still works.
+2. Add the new value as a new secret version.
+3. Restart the affected services.
+4. Destroy the leaked version, and check `gcloud secrets get-iam-policy` for any
+   grant that should not be there.
+5. Purge the value from wherever it appeared, and confirm the `Secret scan` job
+   in `.github/workflows/security.yml` is clean afterwards.
+
+Steps 2–5 without step 1 are theatre.
+
+## Destroying the environment
+
+`terraform destroy` deletes the secret containers, and deleting a container
+deletes every version inside it. There is no undo and no export. Before
+destroying a non-throwaway environment, confirm that every value can be
+regenerated or is stored somewhere else.

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -71,7 +71,7 @@ manager, or a CI-provided temp file).
 
 The full contract — every field, its type, and its allowed values — is
 documented in
-[`schema/project-config.schema.json`](./schema/project-config.schema.json).
+[`project-config.schema.json`](./project-config.schema.json).
 It covers: project ID, environment, region/zone, naming and labels, network
 and subnet CIDRs, bastion settings, and the full list of workload VM
 definitions (machine type, image, disk, internal IP, public-IP policy,
@@ -84,6 +84,7 @@ Two Terraform inputs remain outside the JSON contract:
 | --- | --- |
 | `project_config_path` | Absolute path to the environment-specific JSON configuration file |
 | `ssh_users` | Public SSH keys keyed by Linux username — not environment-specific, supplied separately |
+| `secret_version_managers` | IAM principals allowed to store new secret values. Identities only; never values |
 
 Before the first plan, prepare a JSON file for your environment (e.g.
 `dev.json`) following the schema, and confirm:
@@ -105,6 +106,23 @@ network tags — before any resource is created.
 No domain, application credential, database password, external message
 broker credential, Redis credential or container image input is required by
 the current root.
+
+## Secret Manager
+
+The root creates one Secret Manager container per distinct entry in the
+`secret_ids` field of the VM definitions, and grants each VM's service account
+`roles/secretmanager.secretAccessor` on exactly the secrets it lists — per
+secret, never at project scope. `secretmanager.googleapis.com` is enabled by
+Terraform itself in `apis.tf`, with `disable_on_destroy = false` so a destroy
+cannot break other workloads in the project.
+
+Secret *values* are not managed here: there is no
+`google_secret_manager_secret_version` resource and no input that accepts a
+credential, so no payload reaches Terraform state. Values are added out of band
+and consumed at service start.
+
+See [`docs/secrets.md`](../../docs/secrets.md) for the access map, how to grant
+and revoke, how to store a value, and the rotation procedure.
 
 ## First plan
 

--- a/infrastructure/terraform/apis.tf
+++ b/infrastructure/terraform/apis.tf
@@ -1,0 +1,6 @@
+resource "google_project_service" "secretmanager" {
+  project = local.config.project_id
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+}

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -16,7 +16,7 @@ resource "google_project_iam_member" "workload_automation" {
 resource "google_secret_manager_secret_iam_member" "workload_secret_access" {
   for_each  = { for pair in local.vm_secret_pairs : "${pair.vm_name}-${pair.secret_id}" => pair }
   project   = local.config.project_id
-  secret_id = each.value.secret_id
+  secret_id = google_secret_manager_secret.this[each.value.secret_id].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.workload[each.value.vm_name].email}"
 }

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -121,3 +121,28 @@ output "workload_service_accounts" {
     for role, account in google_service_account.workload : role => account.email
   }
 }
+
+# secrets
+
+output "secret_ids" {
+  description = "Secret Manager secret IDs created from the project configuration. Secret values are never exposed by this configuration."
+  value       = sort([for secret in google_secret_manager_secret.this : secret.secret_id])
+}
+
+output "secret_resource_names" {
+  description = "Fully qualified Secret Manager resource names (projects/*/secrets/*) keyed by secret ID."
+  value = {
+    for id, secret in google_secret_manager_secret.this : id => secret.name
+  }
+}
+
+output "secret_access_map" {
+  description = "Which workload service accounts may read which secret. Use this to review least privilege without opening the console."
+  value = {
+    for secret_id in local.secret_ids : secret_id => sort([
+      for pair in local.vm_secret_pairs :
+      google_service_account.workload[pair.vm_name].email
+      if pair.secret_id == secret_id
+    ])
+  }
+}

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -1,0 +1,34 @@
+locals {
+  secret_ids = toset(flatten([for vm in local.config.vms : vm.secret_ids]))
+
+  secret_version_writers = {
+    for pair in setproduct(tolist(local.secret_ids), var.secret_version_managers) :
+    "${pair[0]}/${pair[1]}" => {
+      secret_id = pair[0]
+      member    = pair[1]
+    }
+  }
+}
+
+resource "google_secret_manager_secret" "this" {
+  for_each = local.secret_ids
+
+  project   = local.config.project_id
+  secret_id = each.value
+  labels    = local.common_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "version_adder" {
+  for_each = local.secret_version_writers
+
+  project   = local.config.project_id
+  secret_id = google_secret_manager_secret.this[each.value.secret_id].secret_id
+  role      = "roles/secretmanager.secretVersionAdder"
+  member    = each.value.member
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -10,3 +10,26 @@ variable "ssh_users" {
   EOT
   type        = map(string)
 }
+
+variable "secret_version_managers" {
+  description = <<-EOT
+    IAM principals allowed to add new versions to the Secret Manager secrets
+    created by this configuration, in full member form, for example
+    "user:name@example.com" or
+    "serviceAccount:deployer@project.iam.gserviceaccount.com".
+
+    This grants write-only access: these principals can store a new secret
+    value, but cannot read existing ones. Secret values themselves are never
+    accepted as Terraform input.
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for member in var.secret_version_managers :
+      can(regex("^(user|group|serviceAccount|principal|principalSet):.+$", member))
+    ])
+    error_message = "Each entry must be a full IAM member string, for example user:you@example.com or serviceAccount:deployer@project.iam.gserviceaccount.com."
+  }
+}


### PR DESCRIPTION
The project JSON already carries a secret_ids list per VM, and iam.tf already grants secretAccessor from it - but nothing created the secrets those grants point at. An apply against any configuration with a non-empty secret_ids therefore failed: Google refuses to set an IAM policy on a secret that does not exist. This creates the containers.

The catalogue is derived from the configuration rather than declared separately: it is the union of every secret_ids entry across all VMs. A secret nothing reads is never created, a secret a VM asks for always is, and the two cannot drift apart because they come from one field.

iam.tf now takes secret_id from the created container instead of the raw string. That makes the ordering explicit rather than accidental, and turns a typo in secret_ids into a plan-time error instead of a failed apply half way through.

Terraform owns the containers and the policy, never the payload. There is no google_secret_manager_secret_version resource and no input that accepts a credential, so no secret value reaches Terraform state. Values are added out of band with `gcloud secrets versions add` and read at service start.

secret_version_managers names the principals allowed to store values. secretVersionAdder lets them write a new version and nothing else - it does not permit reading existing payloads. The list is empty by default, so a fresh clone grants nobody anything.

Outputs expose secret IDs, resource names and the access map. None exposes a value.

Closes #57