### PR TITLE
Add pre-commit hooks that block secrets before they are committed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: detect-private-key
+
+  - repo: local
+    hooks:
+      - id: forbid-secret-files
+        name: Refuse files that carry credentials
+        language: fail
+        entry: >-
+          This kind of file must never be committed. Runtime secrets belong in
+          Google Secret Manager (see docs/secrets.md); Terraform variables and
+          state stay on your machine. If it is already staged, remove it with
+          `git rm --cached <file>`.
+        files: |
+          (?x)^(
+            .*\.env(\..*)?
+            |.*\.tfvars(\.json)?
+            |.*\.tfstate(\..*)?
+            |.*\.(pem|key|p12|pfx)
+            |(.*/)?id_(rsa|dsa|ecdsa|ed25519)
+            |.*-key\.json
+          )$
+        exclude: |
+          (?x)^(
+            .*\.env\.example
+            |.*\.tfvars\.example
+            |.*\.pub
+          )$

--- a/README.md
+++ b/README.md
@@ -317,6 +317,63 @@ both extensions are created idempotently by migration `003_create_ui_sessions.sq
 | `LISTEN_ADDRESS` | `:8002` | Fetcher diagnostic API address |
 | `LOG_LEVEL` | `INFO` | Python service log level |
 
+## Pre-commit hooks
+
+Local checks that run at `git commit`, so a leaked credential is caught while it
+is still only in your working copy. Once a secret reaches a public repository,
+deleting the commit does not undo it — the value has to be treated as
+compromised and rotated at its source. This is the cheapest place to stop that.
+
+Install `pre-commit` once (any of these):
+
+```bash
+brew install pre-commit          # macOS
+uv tool install pre-commit       # anywhere uv is available
+pipx install pre-commit
+```
+
+Then, once per clone:
+
+```bash
+pre-commit install
+```
+
+Check the current working tree straight away — the first run also downloads the
+hook environments, so it takes a minute:
+
+```bash
+pre-commit run --all-files
+```
+
+What runs on every commit:
+
+| Hook | Catches |
+| --- | --- |
+| `gitleaks` | Credentials in the staged diff, by pattern. Scans only what you are committing, not the whole history |
+| `detect-private-key` | PEM and OpenSSH private key blocks, by structure rather than by pattern |
+| `forbid-secret-files` | Whole file classes that must never be committed: `.env*`, `*.tfvars`, `*.tfstate*`, `*.pem`, `*.key`, `id_rsa`/`id_ed25519`, `*-key.json` |
+
+The last one exists because `.gitignore` is bypassed by `git add -f`, by a path
+nobody thought to add, and by anyone who edits their local copy. `.env.example`
+and `*.pub` are allowed through.
+
+Two honest caveats:
+
+- **These hooks are local and skippable.** `git commit --no-verify` walks past
+  all of them. They are a first line of defence, not the enforcement point —
+  the `Secret scan` job in `.github/workflows/security.yml` is what actually
+  blocks a merge.
+- **If a secret is already committed**, removing it in a later commit is not
+  enough; it stays in the history. Rotate the credential at its source first,
+  then clean up. See [`docs/secrets.md`](docs/secrets.md).
+
+If the `gitleaks` hook fails to build on your machine, swap it for the
+container-based variant in `.pre-commit-config.yaml`:
+
+```yaml
+      - id: gitleaks-docker
+```
+
 ## Tests and checks
 
 ```bash
@@ -328,7 +385,8 @@ uv run ruff check .
 
 ## Security notes
 
-- Never commit `.env` or `infrastructure/vagrant/config/vagrant.env`.
+- Never commit `.env` or `infrastructure/vagrant/config/vagrant.env`. Run
+  `pre-commit install` after cloning so this is enforced locally, not just by review.
 - Replace all example passwords before deployment.
 - Reserve the VM addresses and restrict sensitive LAN ports at the router or firewall when
   the network is not trusted.


### PR DESCRIPTION
A secret that reaches a public repository cannot be un-leaked. Deleting the commit does not help: the value has to be treated as compromised and rotated at its source. The Secret scan job already catches this in CI, but by then the value is pushed and, on a public repository, readable. These hooks move the check to `git commit`, where the fix is an edit rather than an incident.

Three layers, deliberately overlapping:

gitleaks scans the staged diff by pattern. Staged only, not the whole history - the historical findings this repository already has would otherwise drown out whatever is actually being committed.

detect-private-key finds PEM and OpenSSH key blocks by structure, which covers material a rule-based scanner misses.

forbid-secret-files rejects whole file classes regardless of content: .env*, *.tfvars, *.tfstate*, *.pem, *.key, id_rsa/id_ed25519, *-key.json. .gitignore already lists most of these, but it is bypassed by `git add -f`, by a path nobody anticipated, and by anyone editing their local copy. .env.example and *.pub are allowed through.

The README documents installation and states plainly what these hooks are not: they are local and `git commit --no-verify` walks past them, so CI remains the enforcement point.