### PR TITLE
fix: Publish database image to GHCR

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -48,3 +48,4 @@ jobs:
       dockerfile: infrastructure/docker/Dockerfile.database
       context: .
       description: Petroscope database
+

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -39,3 +39,12 @@ jobs:
       dockerfile: infrastructure/docker/Dockerfile.ui
       context: .
       description: Petroscope web UI and backend service
+
+  database:
+    name: Publish database image
+    uses: ./.github/workflows/reusable-build-image.yaml
+    with:
+      image-name: ghcr.io/${{ github.repository_owner }}/push-and-pray/database
+      dockerfile: infrastructure/docker/Dockerfile.database
+      context: .
+      description: Petroscope database

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -48,4 +48,3 @@ jobs:
       dockerfile: infrastructure/docker/Dockerfile.database
       context: .
       description: Petroscope database
-


### PR DESCRIPTION
fetcher, history and ui were in `publish_images.yaml`, but database was missing