### PR TITLE
remove-unused-tags

### DIFF
--- a/.github/workflows/reusable-build-image.yaml
+++ b/.github/workflows/reusable-build-image.yaml
@@ -48,13 +48,6 @@ jobs:
           images: ${{ inputs.image-name }}
           tags: |
             type=raw,value=${{ github.sha }}
-            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=raw,value=integration,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
only tag SHA has an actual consumer
The other seven tags exist to serve use cases this project doesn't have