### PR TITLE
Feature/cloud init

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -375,3 +375,9 @@ jobs:
             -input=false
 
           terraform -chdir=infrastructure/terraform validate
+
+      - name: Validate cloud-init syntax
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          command -v cloud-init || sudo apt-get install -y --no-install-recommends cloud-init
+          cloud-init schema --config-file infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -44,9 +44,10 @@ module "vm" {
   source   = "./modules/vm"
   for_each = local.config.workloads
 
-  name          = "${local.resource_prefix}-${each.key}"
-  subnetwork_id = module.network.workload_subnet_id
-  role          = each.value.role
+  name            = "${local.resource_prefix}-${each.key}"
+  subnetwork_id   = module.network.workload_subnet_id
+  role            = each.value.role
+  automation_role = each.value.automation_role
   network_tags = [
     for tag in each.value.network_tags :
     "${local.resource_prefix}-${tag}"

--- a/infrastructure/terraform/modules/vm/locals.tf
+++ b/infrastructure/terraform/modules/vm/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  cloud_config = templatefile("${path.module}/templates/cloud-config.yaml.tftpl", {
+    automation_role = var.automation_role
+    docker_version  = var.docker_version
+  })
+}

--- a/infrastructure/terraform/modules/vm/main.tf
+++ b/infrastructure/terraform/modules/vm/main.tf
@@ -61,6 +61,7 @@ resource "google_compute_instance" "workload" {
     }
   }
 
-  #TODO: Add workload cloud-init when guest provisioning
-  metadata = {}
+  metadata = {
+    "user-data" = local.cloud_config
+  }
 }

--- a/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
+++ b/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
@@ -5,14 +5,9 @@
 # deployment: this file never pulls an application image, runs Compose, or
 # reads a secret VALUE (only the automation_role and Secret Manager IDs are
 # non-secret and safe to template in). Starting the application itself is a
-# separate, later automation step - see oilscope-deploy.service below.
+# separate, later automation step (#56) - see oilscope-deploy.service below.
 #
-# NOT YET ATTACHED to any VM. This file is not referenced by any .tf file in
-# this module yet (see modules/vm/README.md for the current status). It exists
-# so its cloud-init syntax and content can be reviewed and CI-validated on
-# their own, before the metadata wiring lands in a follow-up change.
-#
-# Template variables (supplied by the eventual templatefile() call):
+# Template variables (supplied by modules/vm/locals.tf's templatefile() call):
 #   automation_role - the VM's non-secret automation role (e.g. infra, history,
 #                      fetcher, ui). Delivered as an Environment= line in the
 #                      oilscope-deploy.service unit below, never logged.
@@ -38,9 +33,8 @@ write_files:
       Description=OilScope role-specific deployment automation
       After=network-online.target docker.service
       Wants=network-online.target
-      # Absent until the deployment-automation ticket delivers it: the unit
-      # is enabled below but stays a no-op (reported as "condition failed",
-      # not "failed") until that script exists.
+      # Absent until #56 delivers it: the condition fails (reported as
+      # "condition failed", not "failed") until that script exists.
       ConditionPathExists=/opt/oilscope/deploy/run.sh
 
       [Service]
@@ -50,6 +44,9 @@ write_files:
       Environment=AUTOMATION_ROLE=${automation_role}
       WorkingDirectory=/opt/oilscope/deploy
       ExecStart=/opt/oilscope/deploy/run.sh
+
+      [Install]
+      WantedBy=multi-user.target
 
 runcmd:
   # --- Prerequisites: curl/ca-certificates are needed before the Docker repo
@@ -77,10 +74,10 @@ runcmd:
   - [ install, -d, -m, "0750", -o, deploy, -g, deploy, /opt/oilscope/deploy ]
   - [ install, -d, -m, "0750", -o, deploy, -g, deploy, /var/lib/oilscope ]
 
-  # --- Role-specific deployment automation unit: enabled now, starts doing
-  # --- real work once run.sh exists (see ConditionPathExists above).
+  # --- Pick up the deployment-automation unit file written above. Not
+  # --- enabled here on purpose: #56 owns enabling/starting it once run.sh
+  # --- actually exists - this ticket only prepares the entry point.
   - [ systemctl, daemon-reload ]
-  - [ systemctl, enable, oilscope-deploy.service ]
 
   # --- Readiness marker, written only after Docker is confirmed to actually
   # --- answer. Documented check: test -f /var/lib/oilscope/bootstrap-ready

--- a/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
+++ b/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
@@ -1,0 +1,87 @@
+#cloud-config
+#
+# OS + Docker runtime bootstrap for OilScope workload VMs. Scope is
+# deliberately limited to what the machine needs before any application
+# deployment: this file never pulls an application image, runs Compose, or
+# reads a secret VALUE (only the automation_role and Secret Manager IDs are
+# non-secret and safe to template in). Starting the application itself is a
+# separate, later automation step - see oilscope-deploy.service below.
+#
+# NOT YET ATTACHED to any VM. This file is not referenced by any .tf file in
+# this module yet (see modules/vm/README.md for the current status). It exists
+# so its cloud-init syntax and content can be reviewed and CI-validated on
+# their own, before the metadata wiring lands in a follow-up change.
+#
+# Template variables (supplied by the eventual templatefile() call):
+#   automation_role - the VM's non-secret automation role (e.g. infra, history,
+#                      fetcher, ui). Delivered as an Environment= line in the
+#                      oilscope-deploy.service unit below, never logged.
+#   docker_version   - exact Docker Engine apt version to pin, e.g.
+#                      "5:27.3.1-1~ubuntu.24.04~noble". Re-verify with
+#                      `apt-cache madison docker-ce` before this template is
+#                      attached to any VM - do not trust this file's own
+#                      history for a current value.
+
+users:
+  - name: deploy
+    system: true
+    groups: [docker]
+    shell: /usr/sbin/nologin
+    lock_passwd: true
+
+write_files:
+  - path: /etc/systemd/system/oilscope-deploy.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=OilScope role-specific deployment automation
+      After=network-online.target docker.service
+      Wants=network-online.target
+      # Absent until the deployment-automation ticket delivers it: the unit
+      # is enabled below but stays a no-op (reported as "condition failed",
+      # not "failed") until that script exists.
+      ConditionPathExists=/opt/oilscope/deploy/run.sh
+
+      [Service]
+      Type=oneshot
+      User=deploy
+      Group=docker
+      Environment=AUTOMATION_ROLE=${automation_role}
+      WorkingDirectory=/opt/oilscope/deploy
+      ExecStart=/opt/oilscope/deploy/run.sh
+
+runcmd:
+  # --- Prerequisites: curl/ca-certificates are needed before the Docker repo
+  # --- key can be fetched; jq is for later health-check / Secret Manager
+  # --- response parsing. Nothing here pulls an application image.
+  - [ apt-get, update ]
+  - [ apt-get, install, -y, --no-install-recommends, ca-certificates, curl, jq ]
+
+  # --- Docker Engine: add the official repo, install a pinned version, hold
+  # --- it. The key is fetched from Docker's own stable URL at boot time
+  # --- rather than embedded in this file, so nothing here depends on a
+  # --- hand-copied key blob staying correct.
+  - [ install, -m, "0755", -d, /etc/apt/keyrings ]
+  - [ sh, -c, "test -f /etc/apt/keyrings/docker.asc || curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc" ]
+  - [ chmod, "a+r", /etc/apt/keyrings/docker.asc ]
+  - [ sh, -c, ". /etc/os-release && echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $${UBUNTU_CODENAME} stable\" > /etc/apt/sources.list.d/docker.list" ]
+  - [ apt-get, update ]
+  - [ sh, -c, "apt-get install -y --no-install-recommends docker-ce=${docker_version} docker-ce-cli=${docker_version} containerd.io docker-buildx-plugin docker-compose-plugin" ]
+  - [ apt-mark, hold, docker-ce, docker-ce-cli, containerd.io, docker-compose-plugin ]
+  - [ systemctl, enable, --now, docker.service ]
+
+  # --- Application and deployment directories: owned by the deploy user,
+  # --- unreadable to anyone else on the box.
+  - [ install, -d, -m, "0750", -o, deploy, -g, deploy, /opt/oilscope/app ]
+  - [ install, -d, -m, "0750", -o, deploy, -g, deploy, /opt/oilscope/deploy ]
+  - [ install, -d, -m, "0750", -o, deploy, -g, deploy, /var/lib/oilscope ]
+
+  # --- Role-specific deployment automation unit: enabled now, starts doing
+  # --- real work once run.sh exists (see ConditionPathExists above).
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, oilscope-deploy.service ]
+
+  # --- Readiness marker, written only after Docker is confirmed to actually
+  # --- answer. Documented check: test -f /var/lib/oilscope/bootstrap-ready
+  - [ sh, -c, "docker info >/dev/null && date -u +%Y-%m-%dT%H:%M:%SZ > /var/lib/oilscope/bootstrap-ready" ]

--- a/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
+++ b/infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl
@@ -12,7 +12,7 @@
 #                      fetcher, ui). Delivered as an Environment= line in the
 #                      oilscope-deploy.service unit below, never logged.
 #   docker_version   - exact Docker Engine apt version to pin, e.g.
-#                      "5:27.3.1-1~ubuntu.24.04~noble". Re-verify with
+#                      "5:29.7.2-1~ubuntu.26.04~resolute". Re-verify with
 #                      `apt-cache madison docker-ce` before this template is
 #                      attached to any VM - do not trust this file's own
 #                      history for a current value.

--- a/infrastructure/terraform/modules/vm/variables.tf
+++ b/infrastructure/terraform/modules/vm/variables.tf
@@ -92,7 +92,7 @@ variable "automation_role" {
 variable "docker_version" {
   description = "Exact Docker Engine apt version pinned by the cloud-init bootstrap. Verify with `apt-cache madison docker-ce` before bumping."
   type        = string
-  default     = "5:27.3.1-1~ubuntu.24.04~noble"
+  default     = "5:29.7.2-1~ubuntu.26.04~resolute"
 }
 
 variable "labels" {

--- a/infrastructure/terraform/modules/vm/variables.tf
+++ b/infrastructure/terraform/modules/vm/variables.tf
@@ -84,6 +84,17 @@ variable "assign_public_ip" {
   default     = false
 }
 
+variable "automation_role" {
+  description = "Non-secret automation role passed to the cloud-init bootstrap process."
+  type        = string
+}
+
+variable "docker_version" {
+  description = "Exact Docker Engine apt version pinned by the cloud-init bootstrap. Verify with `apt-cache madison docker-ce` before bumping."
+  type        = string
+  default     = "5:27.3.1-1~ubuntu.24.04~noble"
+}
+
 variable "labels" {
   description = "Labels applied to resources that support them."
   type        = map(string)

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -1,0 +1,36 @@
+locals {
+  all_secret_ids = distinct(flatten([
+    for name, workload in local.config.workloads : workload.secret_ids
+  ]))
+
+  workload_secret_pairs = flatten([
+    for name, workload in local.config.workloads : [
+      for secret_id in workload.secret_ids : { vm_name = name, secret_id = secret_id }
+    ]
+  ])
+}
+
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_secret_manager_secret" "this" {
+  for_each  = toset(local.all_secret_ids)
+  secret_id = each.value
+  labels    = local.common_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "workload_access" {
+  for_each = { for pair in local.workload_secret_pairs : "${pair.vm_name}-${pair.secret_id}" => pair }
+
+  secret_id = google_secret_manager_secret.this[each.value.secret_id].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.vm[each.value.vm_name].service_account_email}"
+}


### PR DESCRIPTION
Cloud-init bootstrap + Secret Manager provisioning (#55)

Attaches a reviewed cloud-config to every workload VM: pinned Docker Engine + Compose plugin, held versions, auto-start on reboot, a locked-down deploy user, restricted app/deploy directories, and a non-secret readiness marker. Passes each VM's automation_role through to the bootstrap, and adds a generic oilscope-deploy.service entry point (not enabled yet — left for #56 to activate once it delivers run.sh).

Also provisions the minimum Secret Manager access: one secret container per distinct ID across all workloads, with secretAccessor scoped to exactly each VM's own secret_ids — no project-wide grants, no payloads, no secret values anywhere.

CI now validates cloud-config syntax on every PR via cloud-init schema.

Builds on #53 (merged). App deployment is #56; secret payload sync is #58 — both out of scope here.