### PR TITLE
Align Secret Manager containers and workload IAM

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,154 @@
+# Secrets
+
+Deployment credentials live in Google Secret Manager. Terraform creates the
+containers and decides who may read them; it never sees, stores or transports a
+value.
+
+## Where the catalog comes from
+
+There is no hand-written list of secrets. Every container is derived from
+`secret_mappings` in the project configuration JSON:
+
+```json
+"vms": {
+  "history": {
+    "role": "history",
+    "secret_mappings": {
+      "DB_PASSWORD_HISTORY": "oilscope-dev-db-password-history"
+    }
+  }
+}
+```
+
+The key is the environment variable the application expects; the value is the
+Secret Manager container ID. Both halves are non-secret, which is why the whole
+mapping can live in a file the repository reads.
+
+`infrastructure/terraform/secrets.tf` flattens those maps into the set of
+containers to create, and into the list of (workload, secret) pairs to grant.
+Giving a workload a new secret is a one-line change to that JSON — the
+container, the grant and the environment-variable name all follow from it.
+
+The same derivation is what makes the access rule enforceable: a workload can
+only be granted a secret that is written next to its own name.
+
+## What Terraform does, and what it deliberately does not
+
+| Terraform | |
+| --- | --- |
+| creates | `google_secret_manager_secret` — the container, automatic replication, project labels |
+| creates | `google_secret_manager_secret_iam_member` — one `roles/secretmanager.secretAccessor` binding per (workload, secret) pair |
+| creates | `google_secret_manager_secret_iam_member` — one `roles/secretmanager.secretVersionAdder` binding per configured version manager |
+| never creates | `google_secret_manager_secret_version` — the payload |
+
+The last row is the whole point. A secret value passed into Terraform ends up in
+three places you cannot fully control: the configuration file, the plan file, and
+the state file. State lives in a bucket, plans get attached to pull requests, and
+neither is a place for a credential. So versions are added out of band and
+Terraform is told nothing about them.
+
+`google_secret_manager_secret_iam_member` is used rather than
+`..._iam_binding`. The `_binding` form is authoritative for the whole role on
+that secret: it silently removes any grant made outside Terraform. `_member` adds
+one principal and leaves the rest of the policy alone.
+
+## Who can read what
+
+The access map is an output, so it can be checked without reading any Terraform:
+
+```bash
+terraform output workload_secret_access
+```
+
+```
+{
+  "fetcher" = ["oilscope-dev-db-password-fetcher", "oilscope-dev-oilpriceapi-key"]
+  "history" = ["oilscope-dev-db-password-history"]
+  ...
+}
+```
+
+Each workload VM runs as its own service account and is granted only the secrets
+listed against it. There is no project-wide `secretAccessor` binding, so a
+compromised VM reaches its own credentials and nothing else. This is also why the
+database passwords are separate secrets rather than one shared value: a single
+password would hand every workload the same blast radius.
+
+`terraform output secret_ids` lists the containers, and
+`terraform output secret_resource_names` gives their fully qualified names.
+None of the three outputs exposes a value.
+
+## Storing a value
+
+Values are written with `gcloud`, from a pipe, never from a command-line
+argument — arguments are visible in `ps` output and land in shell history:
+
+```bash
+printf '%s' "${DB_PASSWORD_HISTORY}" \
+  | gcloud secrets versions add oilscope-dev-db-password-history \
+      --project="${GOOGLE_PROJECT}" --data-file=-
+```
+
+Note `printf` rather than `echo`: `echo` appends a newline, which becomes part of
+the stored value and then fails an exact comparison somewhere far away from here.
+
+Which environment variable holds which value is not a convention to remember —
+it is the key side of `secret_mappings`. Read it from the configuration rather
+than deriving it from the secret's name.
+
+Generate database passwords with `openssl rand -hex 32`. `-hex` rather than
+`-base64`, because base64 contains `+` and `/`, which have to be percent-encoded
+inside a `postgres://` URL and break it if they are not.
+
+Adding versions requires `roles/secretmanager.secretVersionAdder`. That grant is
+made by Terraform from the `secret_version_managers` variable:
+
+```hcl
+secret_version_managers = [
+  "user:name@example.com",
+]
+```
+
+`secretVersionAdder` is deliberately not `secretAccessor`. It allows adding a new
+version and nothing else — a person listed here can rotate a credential without
+being able to read the current one. Reading is what the workload service accounts
+do, and they hold only `secretAccessor`, only on their own secrets.
+
+Leave the list empty and nobody but a project owner can upload a value, which is
+a reasonable default: it fails closed.
+
+## Rotation
+
+Adding a version does not remove the old one. Secret Manager keeps every version
+until it is destroyed, and consumers that ask for `latest` pick up the new value
+on their next read.
+
+```bash
+printf '%s' "${NEW_VALUE}" | gcloud secrets versions add SECRET_ID --data-file=-
+gcloud secrets versions list SECRET_ID
+gcloud secrets versions destroy VERSION --secret=SECRET_ID   # once nothing reads it
+```
+
+Destroy the previous version only after every consumer has restarted. Until then
+it is the rollback.
+
+## If a value leaks
+
+Rotate first, clean up second. A credential that has been pushed to a public
+repository, printed into a CI log or pasted into a chat is compromised from that
+moment; deleting the commit or the log does not undo it.
+
+1. Generate a new value and add it as a new version.
+2. Restart the consumers so they pick it up.
+3. Destroy the leaked version.
+4. Only then remove the exposed copy from wherever it appeared.
+
+`pre-commit` hooks and the `Secret scan` job in CI exist to make step 4 rare —
+see the README and [security-scanning.md](security-scanning.md).
+
+## One caveat on destroy
+
+`terraform destroy` removes the containers and every version inside them. There
+is no undo, and the values are not in state to be recovered from. Before
+destroying a project that anyone else relies on, confirm the values exist
+somewhere else first.

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -51,3 +51,23 @@ output "workload_service_account_emails" {
     for name, vm in module.vm : name => vm.service_account_email
   }
 }
+
+output "secret_ids" {
+  description = "Secret Manager container IDs created from the project configuration."
+  value       = sort(local.all_secret_ids)
+}
+
+output "secret_resource_names" {
+  description = "Fully qualified Secret Manager resource names, by secret ID."
+  value = {
+    for secret_id, secret in google_secret_manager_secret.this : secret_id => secret.name
+  }
+}
+
+output "workload_secret_access" {
+  description = "Secret IDs each workload service account may read. Names only - never values."
+  value = {
+    for name, workload in local.workload_vms :
+    name => sort(distinct(values(workload.secret_mappings)))
+  }
+}

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -11,6 +11,14 @@ locals {
       }
     ]
   ])
+
+  secret_version_writers = {
+    for pair in setproduct(sort(local.all_secret_ids), var.secret_version_managers) :
+    "${pair[0]}/${pair[1]}" => {
+      secret_id = pair[0]
+      member    = pair[1]
+    }
+  }
 }
 
 resource "google_secret_manager_secret" "this" {
@@ -26,9 +34,17 @@ resource "google_secret_manager_secret" "this" {
 }
 
 resource "google_secret_manager_secret_iam_member" "workload_access" {
-  for_each = { for pair in local.workload_secret_pairs : "${pair.vm_name}-${pair.secret_id}" => pair }
+  for_each = { for pair in local.workload_secret_pairs : "${pair.vm_name}/${pair.secret_id}" => pair }
 
   secret_id = google_secret_manager_secret.this[each.value.secret_id].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${module.vm[each.value.vm_name].service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "version_adder" {
+  for_each = local.secret_version_writers
+
+  secret_id = google_secret_manager_secret.this[each.value.secret_id].secret_id
+  role      = "roles/secretmanager.secretVersionAdder"
+  member    = each.value.member
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -13,3 +13,17 @@ variable "project_config_path" {
     error_message = "project_config_path must contain valid JSON using config_version 3."
   }
 }
+
+variable "secret_version_managers" {
+  description = "IAM members allowed to add new versions to every secret. Adding a version does not grant reading one."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for member in var.secret_version_managers :
+      can(regex("^(user|group|serviceAccount|principal|principalSet):.+$", member))
+    ])
+    error_message = "Each entry must be a fully qualified IAM member, for example user:name@example.com."
+  }
+}


### PR DESCRIPTION
Closes #86

Draft until #81, #83 and #84 land — all three touch the files this PR changes:

- #83 renames the VM module, which `secrets.tf` references for the workload
  service-account emails.
- #81 redefines the JSON contract this derives `secret_ids` from.
- #84 will likely move `google_project_service.secretmanager` out of `secrets.tf`.

Ready for review on the approach now; I will rebase once those merge.

Verified: `terraform validate` passes, `plan` is clean, and the plan contains no
`google_secret_manager_secret_version` and no `secret_data`.