### PR TITLE
Enable the minimum required GCP APIs

### DIFF
--- a/infrastructure/terraform/apis.tf
+++ b/infrastructure/terraform/apis.tf
@@ -1,0 +1,21 @@
+locals {
+  required_apis = [
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "secretmanager.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "required" {
+  for_each = toset(local.required_apis)
+
+  service = each.value
+
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
+moved {
+  from = google_project_service.secretmanager
+  to   = google_project_service.required["secretmanager.googleapis.com"]
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -15,6 +15,8 @@ module "network" {
 
   history_api_port = local.config.service_ports.history_api
   postgresql_port  = local.config.service_ports.postgresql
+
+  depends_on = [google_project_service.required]
 }
 
 module "bastion" {
@@ -37,6 +39,8 @@ module "bastion" {
   preemptible       = local.config.bastion.preemptible
 
   labels = merge(local.common_labels, try(local.config.bastion.labels, {}))
+
+  depends_on = [google_project_service.required]
 }
 
 #trivy:ignore:AVD-GCP-0031[assign_public_ip=true]
@@ -69,4 +73,6 @@ module "vm" {
       role = each.value.role
     },
   )
+
+  depends_on = [google_project_service.required]
 }

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -10,11 +10,6 @@ locals {
   ])
 }
 
-resource "google_project_service" "secretmanager" {
-  service            = "secretmanager.googleapis.com"
-  disable_on_destroy = false
-}
-
 resource "google_secret_manager_secret" "this" {
   for_each  = toset(local.all_secret_ids)
   secret_id = each.value
@@ -24,7 +19,7 @@ resource "google_secret_manager_secret" "this" {
     auto {}
   }
 
-  depends_on = [google_project_service.secretmanager]
+  depends_on = [google_project_service.required]
 }
 
 resource "google_secret_manager_secret_iam_member" "workload_access" {


### PR DESCRIPTION
Terraform enabled a single API, secretmanager, from inside secrets.tf. Compute Engine and IAM were assumed to be on already, which holds only because the project happened to be bootstrapped by hand.

- apis.tf enables exactly the three APIs this configuration needs.
- disable_on_destroy = false on each: disabling an API is a project-wide action that would affect anything else living in that project.
- network, bastion and vm depend on google_project_service.required, so no resource is created before the API serving it is active.
- A moved block carries the old google_project_service.secretmanager address across, so anyone who already applied this to their own project gets a rename rather than a destroy and recreate.

serviceusage and cloudresourcemanager are deliberately absent: both must be active before Terraform can enable anything at all, and Google turns them on when the project is created.

Closes #84