### PR TITLE
Create the Ansible database role

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/database/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/database/README.md
@@ -1,0 +1,62 @@
+# Database role
+
+Pulls the immutable OilScope PostgreSQL image, starts the database service,
+waits for its Docker health check, and applies the bundled SQL migrations.
+
+## Requirements
+
+The target must have Docker with the Compose plugin installed. The supported
+Compose definition must already be installed on the target; use the
+`oilscope.platform.compose_project` role for that step.
+
+The database image must contain `petroscope-migrate` and the migrations under
+`/opt/petroscope/migrations`, as defined by `Dockerfile.database`.
+
+## Required variables
+
+- `database_postgres_image`: complete image reference pinned with
+  `@sha256:<64 hexadecimal characters>`.
+- `database_application_image_tag`: full 40-character Git SHA required while
+  rendering the shared Compose definition. Application services are not
+  started by this role.
+- `database_postgres_password`: password supplied by the deployment secret
+  mechanism. The role marks tasks receiving it with `no_log` and does not write
+  it to disk.
+
+## Optional variables
+
+- `database_compose_project_dir`: Compose directory; defaults to
+  `/opt/oilscope/app`.
+- `database_compose_file`: Compose file; defaults to `compose.yaml` in that
+  directory.
+- `database_postgres_user` and `database_postgres_name`: both default to
+  `oil_tracker`.
+- `database_bind_address`: defaults to `0.0.0.0`.
+- `database_host_port`: defaults to `5432`.
+- `database_health_retries` and `database_health_delay`: health polling
+  controls, defaulting to 30 attempts every 2 seconds.
+- `database_compose_environment`: additional non-secret Compose environment.
+
+## Example
+
+```yaml
+---
+- name: Deploy the database
+  hosts: database
+  become: true
+  roles:
+    - role: oilscope.platform.database
+      vars:
+        database_postgres_image: >-
+          ghcr.io/ua-academy-projects/push-and-pray/database@sha256:...
+        database_application_image_tag: 0123456789abcdef0123456789abcdef01234567
+        database_postgres_password: "{{ vault_database_password }}"
+```
+
+Running the role again is safe: Compose reconciles the existing PostgreSQL
+container and the bundled migrations use idempotent SQL operations. The
+migration container is removed after every successful run.
+
+## License
+
+GPL-2.0-or-later

--- a/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+database_compose_project_dir: /opt/oilscope/app
+database_compose_file: "{{ database_compose_project_dir }}/compose.yaml"
+database_compose_project_name: petroscope
+database_postgres_service: postgres
+database_migration_service: migrate
+database_postgres_image: ""
+database_application_image_tag: ""
+database_postgres_password: ""
+database_postgres_user: oil_tracker
+database_postgres_name: oil_tracker
+database_bind_address: 0.0.0.0
+database_host_port: 5432
+database_health_retries: 30
+database_health_delay: 2
+database_compose_environment: {}

--- a/infrastructure/ansible/oilscope/platform/roles/database/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+[]

--- a/infrastructure/ansible/oilscope/platform/roles/database/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/meta/main.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Deploy the OilScope PostgreSQL service and run migrations
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  galaxy_tags:
+    - database
+    - docker
+    - postgresql
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/database/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/tasks/main.yml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate database deployment variables
+  ansible.builtin.assert:
+    that:
+      - database_compose_file | length > 0
+      - database_postgres_image is match('^.+@sha256:[0-9a-f]{64}$')
+      - database_application_image_tag is match('^[0-9a-f]{40}$')
+      - database_postgres_password | length > 0
+      - database_health_retries | int > 0
+      - database_health_delay | int >= 0
+    fail_msg: >-
+      database_compose_file and database_postgres_password are required, and
+      database_postgres_image must be pinned to a sha256 digest. The
+      database_application_image_tag must be a full 40-character Git SHA so
+      the shared Compose definition can be rendered.
+  no_log: true
+
+- name: Check the Compose definition
+  ansible.builtin.stat:
+    path: "{{ database_compose_file }}"
+  register: database_compose_definition
+
+- name: Require the Compose definition
+  ansible.builtin.assert:
+    that:
+      - database_compose_definition.stat.isreg | default(false)
+    fail_msg: "Compose definition not found at {{ database_compose_file }}."
+
+- name: Pull the exact PostgreSQL image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - image
+      - pull
+      - "{{ database_postgres_image }}"
+  register: database_image_pull
+  changed_when: >-
+    'Downloaded newer image' in database_image_pull.stdout or
+    'Pull complete' in database_image_pull.stdout
+
+- name: Start the PostgreSQL service
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ database_compose_project_name }}"
+      - --file
+      - "{{ database_compose_file }}"
+      - up
+      - --detach
+      - --no-deps
+      - "{{ database_postgres_service }}"
+  args:
+    chdir: "{{ database_compose_project_dir }}"
+  environment: "{{ database_runtime_environment }}"
+  register: database_compose_up
+  changed_when: >-
+    'Created' in database_compose_up.stderr or
+    'Started' in database_compose_up.stderr or
+    'Recreated' in database_compose_up.stderr
+  no_log: true
+
+- name: Get the PostgreSQL container ID
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ database_compose_project_name }}"
+      - --file
+      - "{{ database_compose_file }}"
+      - ps
+      - --quiet
+      - "{{ database_postgres_service }}"
+  args:
+    chdir: "{{ database_compose_project_dir }}"
+  environment: "{{ database_runtime_environment }}"
+  register: database_container
+  changed_when: false
+  failed_when: database_container.stdout | trim | length == 0
+  no_log: true
+
+- name: Wait for PostgreSQL to become healthy
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - --format
+      - "{{ '{{' }}if .State.Health{{ '}}' }}{{ '{{' }}.State.Health.Status{{ '}}' }}{{ '{{' }}else{{ '}}' }}missing{{ '{{' }}end{{ '}}' }}"
+      - "{{ database_container.stdout | trim }}"
+  register: database_health
+  changed_when: false
+  retries: "{{ database_health_retries }}"
+  delay: "{{ database_health_delay }}"
+  until: database_health.stdout | trim == 'healthy'
+
+- name: Apply database migrations
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ database_compose_project_name }}"
+      - --file
+      - "{{ database_compose_file }}"
+      - run
+      - --rm
+      - --no-deps
+      - "{{ database_migration_service }}"
+  args:
+    chdir: "{{ database_compose_project_dir }}"
+  environment: "{{ database_runtime_environment }}"
+  register: database_migrations
+  changed_when: "'Applying ' in database_migrations.stdout"
+  no_log: true

--- a/infrastructure/ansible/oilscope/platform/roles/database/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/database/tests/inventory
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/infrastructure/ansible/oilscope/platform/roles/database/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/tests/test.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate the database role
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include the role with an invalid mutable image reference
+      ansible.builtin.include_role:
+        name: database
+      vars:
+        database_postgres_image: postgres:18
+        database_application_image_tag: 0123456789abcdef0123456789abcdef01234567
+        database_postgres_password: test-only
+      register: database_invalid_image
+      ignore_errors: true
+
+    - name: Verify mutable image references are rejected
+      ansible.builtin.assert:
+        that:
+          - database_invalid_image is failed

--- a/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+database_runtime_environment: >-
+  {{
+    database_compose_environment
+    | combine({
+      'POSTGRES_IMAGE': database_postgres_image,
+      'APP_IMAGE_TAG': database_application_image_tag,
+      'POSTGRES_PASSWORD': database_postgres_password,
+      'POSTGRES_USER': database_postgres_user,
+      'POSTGRES_DB': database_postgres_name,
+      'DATABASE_BIND_ADDRESS': database_bind_address | string,
+      'DATABASE_HOST_PORT': database_host_port | string
+    })
+  }}


### PR DESCRIPTION
Closes #98

## Summary
- add the oilscope.platform.database role
- require and pull an immutable PostgreSQL image digest
- start PostgreSQL and wait for Docker health status
- run the one-shot migration service safely on repeated deployments
- keep the database password out of files and Ansible logs

## Validation
- parsed all role YAML files successfully
- checked line lengths and whitespace
- Docker Compose CLI is available
- full ansible-playbook syntax-check is pending Linux CI because the local Windows host reports CP1251 instead of UTF-8