### PR TITLE
Add Ansible host baseline role

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/README.md
@@ -1,0 +1,40 @@
+# host_baseline
+
+Prepares Ubuntu workload VMs with the common operating-system state required
+before Docker and application roles run. The role installs prerequisite
+packages, creates the locked deployment account, and manages OilScope
+directories and permissions.
+
+## Requirements
+
+- Ansible Core 2.21 or newer.
+- An Ubuntu managed host with Python available.
+- An SSH user permitted to use privilege escalation.
+
+## Variables
+
+- `host_baseline_deploy_user`: deployment system user; defaults to `deploy`.
+- `host_baseline_deploy_group`: deployment system group; defaults to `deploy`.
+- `host_baseline_packages`: packages installed on every workload VM.
+- `host_baseline_directories`: directories with their owner, group, and mode.
+
+See `defaults/main.yml` for the complete default values.
+
+## Dependencies
+
+None. Docker, Compose, runtime secrets, and application services are managed by
+separate collection roles.
+
+## Usage
+
+```yaml
+---
+- name: Prepare OilScope workload hosts
+  hosts: workloads
+  become: true
+  roles:
+    - oilscope.platform.host_baseline
+```
+
+The production inventory is supplied separately. For an isolated role test,
+provide an external inventory containing a `host_baseline_test` group.

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/defaults/main.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT-0
+---
+# defaults file for host_baseline
+host_baseline_deploy_user: deploy
+host_baseline_deploy_group: deploy
+
+host_baseline_packages:
+  - ca-certificates
+  - curl
+  - jq
+
+host_baseline_directories:
+  - path: /opt/oilscope
+    owner: root
+    group: root
+    mode: "0755"
+
+  - path: /opt/oilscope/app
+    owner: "{{ host_baseline_deploy_user }}"
+    group: "{{ host_baseline_deploy_group }}"
+    mode: "0750"
+
+  - path: /opt/oilscope/deploy
+    owner: "{{ host_baseline_deploy_user }}"
+    group: "{{ host_baseline_deploy_group }}"
+    mode: "0750"
+
+  - path: /var/lib/oilscope
+    owner: "{{ host_baseline_deploy_user }}"
+    group: "{{ host_baseline_deploy_group }}"
+    mode: "0750"

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+---
+# handlers file for host_baseline

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/meta/main.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT-0
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Common OS baseline for OilScope workload VMs
+  license: MIT-0
+  min_ansible_version: "2.21"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - infrastructure
+    - linux
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/tasks/main.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT-0
+---
+# tasks file for host_baseline
+- name: Install baseline packages
+  become: true
+  ansible.builtin.apt:
+    name: "{{ host_baseline_packages }}"
+    state: present
+    cache_valid_time: 3600
+    install_recommends: false
+
+- name: Create deployment group
+  become: true
+  ansible.builtin.group:
+    name: "{{ host_baseline_deploy_group }}"
+    system: true
+    state: present
+
+- name: Create locked deployment user
+  become: true
+  ansible.builtin.user:
+    name: "{{ host_baseline_deploy_user }}"
+    group: "{{ host_baseline_deploy_group }}"
+    system: true
+    create_home: false
+    shell: /usr/sbin/nologin
+    password_lock: true
+    state: present
+
+- name: Create OilScope directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+    state: directory
+  loop: "{{ host_baseline_directories }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/inventory
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT-0
+# Supply test hosts through an external inventory. The inventory must define
+# the host_baseline_test group used by test.yml.
+[host_baseline_test]

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/test.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT-0
+---
+- name: Test the host_baseline role
+  hosts: host_baseline_test
+  become: true
+  roles:
+    - oilscope.platform.host_baseline

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/tests/test.yml
@@ -3,5 +3,7 @@
 - name: Test the host_baseline role
   hosts: host_baseline_test
   become: true
-  roles:
-    - oilscope.platform.host_baseline
+  tasks:
+    - name: Include the host_baseline role
+      ansible.builtin.include_role:
+        name: oilscope.platform.host_baseline

--- a/infrastructure/ansible/oilscope/platform/roles/host_baseline/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/host_baseline/vars/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+---
+# vars file for host_baseline


### PR DESCRIPTION
- Created ansible-galaxy host_baseline role inside the collection’s roles/ directory.
- Role manages prerequisite packages, deploy user, application directories and so on.

Closes #94 .