### PR TITLE
Create docker_engine ansible role 

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
@@ -1,0 +1,65 @@
+# Docker Engine
+
+Installs a pinned Docker Engine with the Compose plugin from Docker's official
+apt repository, holds the pinned packages, and enables the service.
+
+This role reproduces the Docker portion of the Terraform cloud-init bootstrap
+in `infrastructure/terraform/modules/vm/templates/cloud-config.yaml.tftpl` so
+that bootstrap can eventually be removed.
+
+## Requirements
+
+The target must be a Debian-family host with outbound access to
+`download.docker.com`. Privilege escalation is required; the role requests it
+per task.
+
+Prerequisite packages (`ca-certificates`, `curl`, `jq`), the `deploy` account
+and the OilScope directories belong to `host_baseline` and are not installed
+here. The role fetches the signing key with `ansible.builtin.get_url` rather
+than `curl`, so it does not depend on `host_baseline` having run first —
+though the deployment playbook applies the baseline first regardless.
+
+## Role variables
+
+- `docker_engine_version`: exact apt version for the pinned packages; defaults
+  to `5:29.7.2-1~ubuntu.26.04~resolute`. Re-verify with
+  `apt-cache madison docker-ce` before bumping.
+- `docker_engine_pinned_packages`: packages installed at that exact version;
+  defaults to `docker-ce` and `docker-ce-cli`.
+- `docker_engine_packages`: packages installed unversioned; defaults to
+  `containerd.io`, `docker-buildx-plugin` and `docker-compose-plugin`.
+- `docker_engine_hold` and `docker_engine_held_packages`: whether to mark
+  packages `hold`, and which ones. Enabled by default.
+- `docker_engine_validate_release`: refuse to run when the pinned version was
+  built for a different Ubuntu release. Enabled by default.
+- `docker_engine_keyring_path`, `docker_engine_gpg_url`,
+  `docker_engine_repository_url`, `docker_engine_repository_component`,
+  `docker_engine_repository_path`: signing key and repository locations.
+- `docker_engine_service`, `docker_engine_service_enabled`,
+  `docker_engine_service_state`: systemd service management.
+- `docker_engine_group` and `docker_engine_group_members`: accounts granted
+  access to the Docker socket. Members that do not exist on the target are
+  skipped rather than created.
+
+The repository is written in deb822 format to
+`/etc/apt/sources.list.d/docker.sources`. The apt cache is refreshed only when
+that file changes, which keeps a repeat run free of changes.
+
+## Dependencies
+
+None declared. The deployment playbook applies `host_baseline` before this
+role.
+
+## Example playbook
+
+```yaml
+---
+- name: Install Docker Engine
+  hosts: workloads
+  roles:
+    - role: oilscope.platform.docker_engine
+```
+
+## License
+
+GPL-2.0-or-later

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# Exact apt version of Docker Engine to install. The release suffix ties the
+# value to one Ubuntu release, so re-verify with `apt-cache madison docker-ce`
+# before bumping it. Kept in step with the Terraform cloud-init bootstrap in
+# infrastructure/terraform/modules/vm/variables.tf.
+docker_engine_version: "5:29.7.2-1~ubuntu.26.04~resolute"
+
+# Packages installed at the pinned version above.
+docker_engine_pinned_packages:
+  - docker-ce
+  - docker-ce-cli
+
+# Packages installed at whatever version the repository offers.
+docker_engine_packages:
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+
+# Packages marked "hold" so an unattended upgrade cannot move them.
+docker_engine_hold: true
+docker_engine_held_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-compose-plugin
+
+# Refuse to run when the pinned version was built for another Ubuntu release.
+docker_engine_validate_release: true
+
+# Repository and signing key.
+docker_engine_keyring_path: /etc/apt/keyrings/docker.asc
+docker_engine_gpg_url: https://download.docker.com/linux/ubuntu/gpg
+docker_engine_repository_url: https://download.docker.com/linux/ubuntu
+docker_engine_repository_component: stable
+docker_engine_repository_path: /etc/apt/sources.list.d/docker.sources
+
+# Service management.
+docker_engine_service: docker
+docker_engine_service_enabled: true
+docker_engine_service_state: started
+
+# Accounts granted access to the Docker socket. Members that do not exist on
+# the target are skipped rather than created; host_baseline owns the deploy
+# account itself.
+docker_engine_group: docker
+docker_engine_group_members:
+  - deploy

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/handlers/main.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Refresh the apt cache
+  become: true
+  ansible.builtin.apt:
+    update_cache: true

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/meta/main.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Install a pinned Docker Engine and the Compose plugin
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  galaxy_tags:
+    - docker
+    - infrastructure
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate Docker Engine role variables
+  ansible.builtin.assert:
+    that:
+      - docker_engine_version | length > 0
+      - docker_engine_pinned_packages | length > 0
+      - docker_engine_keyring_path | length > 0
+      - docker_engine_repository_path | length > 0
+    fail_msg: >-
+      docker_engine_version must name an exact apt version, and
+      docker_engine_pinned_packages, docker_engine_keyring_path and
+      docker_engine_repository_path must not be empty.
+
+- name: Validate the target distribution
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['os_family'] == 'Debian'
+      - ansible_facts['distribution_release'] | length > 0
+    fail_msg: >-
+      docker_engine supports Debian-family hosts only. This host reports
+      os_family {{ ansible_facts['os_family'] | default('unknown') }}.
+
+- name: Validate the pinned version against the host release
+  ansible.builtin.assert:
+    that:
+      - >-
+        docker_engine_version
+        is search('~' ~ ansible_facts['distribution_release'] ~ '$')
+    fail_msg: >-
+      docker_engine_version {{ docker_engine_version }} was built for another
+      Ubuntu release; this host runs
+      {{ ansible_facts['distribution_release'] }}. Confirm the available
+      versions with `apt-cache madison docker-ce` before changing the pin.
+  when: docker_engine_validate_release | bool
+
+- name: Create the apt keyring directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ docker_engine_keyring_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install the Docker repository signing key
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ docker_engine_gpg_url }}"
+    dest: "{{ docker_engine_keyring_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install the Docker apt repository
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ docker_engine_repository_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      Types: deb
+      URIs: {{ docker_engine_repository_url }}
+      Suites: {{ ansible_facts['distribution_release'] }}
+      Components: {{ docker_engine_repository_component }}
+      Architectures: {{ docker_engine_architecture }}
+      Signed-By: {{ docker_engine_keyring_path }}
+  notify: Refresh the apt cache
+
+# The cache must be current before the install task below, and handlers would
+# otherwise not run until the end of the play.
+- name: Apply a pending apt cache refresh
+  ansible.builtin.meta: flush_handlers
+
+- name: Install Docker Engine and the Compose plugin
+  become: true
+  ansible.builtin.apt:
+    name: "{{ docker_engine_package_specs }}"
+    state: present
+    install_recommends: false
+
+- name: Hold the pinned Docker packages
+  become: true
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ docker_engine_held_packages }}"
+  when: docker_engine_hold | bool
+
+- name: Enable and start the Docker service
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ docker_engine_service }}"
+    enabled: "{{ docker_engine_service_enabled }}"
+    state: "{{ docker_engine_service_state }}"
+
+- name: Read the local account database
+  ansible.builtin.getent:
+    database: passwd
+
+- name: Grant Docker socket access to service accounts
+  become: true
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: "{{ docker_engine_group }}"
+    append: true
+  loop: "{{ docker_engine_group_members }}"
+  when: item in ansible_facts['getent_passwd']

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/tests/inventory
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+localhost
+

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/tests/test.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate the Docker Engine role
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Include the role with a version pinned to another release
+      ansible.builtin.include_role:
+        name: docker_engine
+      vars:
+        docker_engine_version: "5:0.0.0-0~ubuntu.00.00~nonexistent"
+      register: docker_engine_wrong_release
+      ignore_errors: true
+
+    - name: Verify a mismatched release pin is rejected
+      ansible.builtin.assert:
+        that:
+          - docker_engine_wrong_release is failed
+        fail_msg: >-
+          The role must refuse a docker_engine_version built for a release
+          other than the one the host runs.

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/vars/main.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# Ansible reports the kernel architecture; apt wants the dpkg name.
+docker_engine_architecture_map:
+  x86_64: amd64
+  aarch64: arm64
+  armv7l: armhf
+
+docker_engine_architecture: >-
+  {{
+    docker_engine_architecture_map.get(
+      ansible_facts['architecture'], ansible_facts['architecture']
+    )
+  }}
+
+# Pinned packages become "name=version"; the rest stay unversioned.
+docker_engine_package_specs: >-
+  {{
+    docker_engine_pinned_packages
+    | product([docker_engine_version])
+    | map('join', '=')
+    | list
+    + docker_engine_packages
+  }}


### PR DESCRIPTION
Closes #95 

- Created Assible **docker_engine** role inside **roles/** directory
- Role installs Docker Engine and Compose plugin on instances, enables Docker services and grants Docker socket access to service accounts