### PR TITLE
Closes #101 / Add Ansible UI role

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/ui/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/README.md
@@ -1,0 +1,82 @@
+# UI role
+
+Pulls and starts only the OilScope `ui` service from the shared deployment
+Compose project, then verifies its public `/health` endpoint.
+
+## Requirements
+
+The target must have Docker with the Compose plugin installed. The
+`oilscope.platform.compose_project` role must already have installed the shared
+Compose definition at `/opt/oilscope/app/compose.yaml`.
+
+Inventory must contain exactly one host in each of the `database` and `history`
+groups. Both hosts must define `internal_ip`, the private address field in the
+project configuration contract. All three names can be changed through
+`ui_database_inventory_group`, `ui_history_inventory_group`, and
+`ui_inventory_private_address_var` if an external inventory maps the same
+contract differently.
+
+## Required variables
+
+- `ui_application_image_tag`: full 40-character Git SHA for the UI image.
+- `ui_postgres_image`: complete PostgreSQL image reference pinned with
+  `@sha256:<64 hexadecimal characters>`. Compose requires this while parsing
+  the shared file, but this role never pulls or starts that image.
+- `ui_postgres_password`: PostgreSQL password injected by the runtime secret
+  mechanism. Sensitive Compose operations use `no_log`, and the value is not
+  written to disk by this role.
+- `ui_health_host`: public UI DNS name or external IP reachable from
+  `ui_health_delegate_to`. The repository exposes UI addresses through the
+  Terraform `workload_external_ips` output, but does not currently define how
+  that output is mapped into Ansible inventory. The deployment inventory or
+  playbook must therefore set this variable explicitly. It deliberately does
+  not default to `ansible_host`, which may be a private SSH transport address.
+
+The pending `gcp_runtime_secrets` role can provide `ui_postgres_password`
+directly when it is introduced. This role deliberately has no Secret Manager
+lookup or fallback credential.
+
+## Optional variables
+
+- `ui_compose_project_dir`, `ui_compose_file`, and
+  `ui_compose_project_name`: shared Compose project settings; defaults match
+  the existing roles (`/opt/oilscope/app`, `compose.yaml`, and `petroscope`).
+- `ui_database_port` and `ui_history_port`: internal service ports; default to
+  `5432` and `8001`.
+- `ui_bind_address` and `ui_http_port`: public listener; default to `0.0.0.0:80`.
+- `ui_postgres_user`, `ui_postgres_name`, and `ui_database_sslmode`: database
+  connection settings.
+- `ui_session_ttl_seconds`, `ui_session_cookie_secure`, and `ui_log_level`: UI
+  runtime settings.
+- `ui_compose_environment`: additional Compose environment values. Explicit
+  role values take precedence when dictionaries are combined.
+- `ui_health_delegate_to`: host that performs the public check; defaults to the
+  Ansible controller (`localhost`).
+- `ui_health_scheme`, `ui_health_path`, `ui_health_status_code`,
+  `ui_health_retries`, `ui_health_delay`, and `ui_health_validate_certs`: public
+  health-check settings.
+
+## Example
+
+```yaml
+---
+- name: Deploy the UI
+  hosts: ui
+  become: true
+  roles:
+    - role: oilscope.platform.ui
+      vars:
+        ui_application_image_tag: 0123456789abcdef0123456789abcdef01234567
+        ui_postgres_image: >-
+          ghcr.io/ua-academy-projects/push-and-pray/database@sha256:...
+        ui_postgres_password: "{{ runtime_secrets.POSTGRES_PASSWORD }}"
+        ui_health_host: "{{ ui_public_address }}"
+```
+
+The role runs the equivalents of `docker compose pull ui` and
+`docker compose up --detach --no-deps ui`. It does not start PostgreSQL,
+Migrate, History, or Fetcher.
+
+## License
+
+GPL-2.0-or-later

--- a/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+ui_compose_project_dir: /opt/oilscope/app
+ui_compose_file: "{{ ui_compose_project_dir }}/compose.yaml"
+ui_compose_project_name: petroscope
+
+ui_application_image_tag: ""
+ui_postgres_image: ""
+ui_postgres_password: ""
+ui_postgres_user: oil_tracker
+ui_postgres_name: oil_tracker
+ui_database_sslmode: disable
+ui_compose_environment: {}
+
+ui_database_inventory_group: database
+ui_history_inventory_group: history
+ui_inventory_private_address_var: internal_ip
+ui_database_port: 5432
+ui_history_port: 8001
+
+ui_bind_address: 0.0.0.0
+ui_http_port: 80
+ui_session_ttl_seconds: 2592000
+ui_session_cookie_secure: false
+ui_log_level: INFO
+
+ui_health_scheme: http
+ui_health_host: ""
+ui_health_path: /health
+ui_health_status_code: 200
+ui_health_retries: 30
+ui_health_delay: 2
+ui_health_validate_certs: true
+ui_health_delegate_to: localhost

--- a/infrastructure/ansible/oilscope/platform/roles/ui/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# This role has no handlers.

--- a/infrastructure/ansible/oilscope/platform/roles/ui/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/meta/main.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Deploy the OilScope public UI service
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  galaxy_tags:
+    - docker
+    - ui
+    - web
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate UI inventory group names
+  ansible.builtin.assert:
+    that:
+      - ui_database_inventory_group | length > 0
+      - ui_history_inventory_group | length > 0
+      - ui_database_inventory_group in groups
+      - ui_history_inventory_group in groups
+    fail_msg: >-
+      Inventory groups named by ui_database_inventory_group and
+      ui_history_inventory_group must exist.
+
+- name: Validate UI inventory group membership
+  ansible.builtin.assert:
+    that:
+      - groups[ui_database_inventory_group] | length == 1
+      - groups[ui_history_inventory_group] | length == 1
+    fail_msg: >-
+      The {{ ui_database_inventory_group }} and
+      {{ ui_history_inventory_group }} inventory groups must each contain
+      exactly one host.
+
+- name: Select the Database and History inventory hosts
+  ansible.builtin.set_fact:
+    ui_database_inventory_host: "{{ groups[ui_database_inventory_group][0] }}"
+    ui_history_inventory_host: "{{ groups[ui_history_inventory_group][0] }}"
+
+- name: Validate private service addresses in inventory
+  ansible.builtin.assert:
+    that:
+      - >-
+        ui_inventory_private_address_var in
+        hostvars[ui_database_inventory_host]
+      - >-
+        hostvars[ui_database_inventory_host]
+        [ui_inventory_private_address_var] | string | length > 0
+      - >-
+        ui_inventory_private_address_var in
+        hostvars[ui_history_inventory_host]
+      - >-
+        hostvars[ui_history_inventory_host]
+        [ui_inventory_private_address_var] | string | length > 0
+    fail_msg: >-
+      Database host {{ ui_database_inventory_host }} and History host
+      {{ ui_history_inventory_host }} must each define the private address
+      variable {{ ui_inventory_private_address_var }}.
+
+- name: Resolve private service endpoints from inventory
+  ansible.builtin.set_fact:
+    ui_database_address: >-
+      {{ hostvars[ui_database_inventory_host]
+         [ui_inventory_private_address_var] }}
+    ui_history_address: >-
+      {{ hostvars[ui_history_inventory_host]
+         [ui_inventory_private_address_var] }}
+    ui_history_service_url: >-
+      http://{{ hostvars[ui_history_inventory_host]
+                [ui_inventory_private_address_var] }}:{{ ui_history_port }}
+
+- name: Validate UI deployment variables
+  ansible.builtin.assert:
+    that:
+      - ui_compose_project_dir | length > 0
+      - ui_compose_file | length > 0
+      - ui_compose_project_name | length > 0
+      - ui_application_image_tag is match('^[0-9a-f]{40}$')
+      - ui_postgres_image is match('^.+@sha256:[0-9a-f]{64}$')
+      - ui_postgres_user | length > 0
+      - ui_postgres_name | length > 0
+      - ui_database_sslmode | length > 0
+      - ui_database_port | int > 0
+      - ui_database_port | int <= 65535
+      - ui_history_port | int > 0
+      - ui_history_port | int <= 65535
+      - ui_bind_address | string | length > 0
+      - ui_http_port | int > 0
+      - ui_http_port | int <= 65535
+      - ui_health_scheme in ['http', 'https']
+      - ui_health_host | length > 0
+      - ui_health_path is match('^/')
+      - ui_health_status_code | int >= 100
+      - ui_health_status_code | int <= 599
+      - ui_health_retries | int > 0
+      - ui_health_delay | int >= 0
+    fail_msg: >-
+      UI deployment requires a full 40-character application image SHA, a
+      PostgreSQL image pinned to a sha256 digest, valid service ports, and
+      valid Compose and database settings. ui_health_host must be the public
+      UI address reachable from ui_health_delegate_to.
+
+- name: Require an injected PostgreSQL password
+  ansible.builtin.fail:
+    msg: >-
+      ui_postgres_password is required and must be supplied by the runtime
+      secret mechanism.
+  when: ui_postgres_password | length == 0
+
+- name: Check the shared Compose definition
+  ansible.builtin.stat:
+    path: "{{ ui_compose_file }}"
+  register: ui_compose_definition
+
+- name: Require the shared Compose definition
+  ansible.builtin.assert:
+    that:
+      - ui_compose_definition.stat.isreg | default(false)
+    fail_msg: "Shared Compose definition not found at {{ ui_compose_file }}."
+
+- name: Pull only the UI image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ ui_compose_project_name }}"
+      - --file
+      - "{{ ui_compose_file }}"
+      - pull
+      - "{{ ui_compose_service }}"
+  args:
+    chdir: "{{ ui_compose_project_dir }}"
+  environment: "{{ ui_runtime_environment }}"
+  register: ui_compose_pull
+  changed_when: >-
+    'Downloaded newer image' in ui_compose_pull.stdout or
+    'Downloaded newer image' in ui_compose_pull.stderr or
+    'Pull complete' in ui_compose_pull.stdout or
+    'Pull complete' in ui_compose_pull.stderr
+  no_log: true
+
+- name: Start only the UI service without dependencies
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ ui_compose_project_name }}"
+      - --file
+      - "{{ ui_compose_file }}"
+      - up
+      - --detach
+      - --no-deps
+      - "{{ ui_compose_service }}"
+  args:
+    chdir: "{{ ui_compose_project_dir }}"
+  environment: "{{ ui_runtime_environment }}"
+  register: ui_compose_up
+  changed_when: >-
+    'Created' in ui_compose_up.stderr or
+    'Started' in ui_compose_up.stderr or
+    'Recreated' in ui_compose_up.stderr
+  no_log: true
+
+- name: Wait for the public UI health endpoint
+  become: false
+  ansible.builtin.uri:
+    url: >-
+      {{ ui_health_scheme }}://{{ ui_health_host }}:{{ ui_http_port
+      }}{{ ui_health_path }}
+    method: GET
+    status_code: "{{ ui_health_status_code }}"
+    validate_certs: "{{ ui_health_validate_certs }}"
+    return_content: false
+  delegate_to: "{{ ui_health_delegate_to }}"
+  register: ui_public_health
+  changed_when: false
+  retries: "{{ ui_health_retries }}"
+  delay: "{{ ui_health_delay }}"
+  until: >-
+    ui_public_health.status | default(0) == ui_health_status_code | int

--- a/infrastructure/ansible/oilscope/platform/roles/ui/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/tests/inventory
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+[ui]
+ui-test ansible_connection=local internal_ip=ui-private-address
+
+[database]
+database-test internal_ip=database-private-address
+
+[history]
+history-test internal_ip=history-private-address

--- a/infrastructure/ansible/oilscope/platform/roles/ui/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/tests/test.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate the UI role
+  hosts: ui
+  gather_facts: false
+  tasks:
+    - name: Initialize validation result
+      ansible.builtin.set_fact:
+        ui_invalid_image_tag_rejected: false
+
+    - name: Exercise immutable image tag validation
+      block:
+        - name: Include the role with an invalid mutable image tag
+          ansible.builtin.include_role:
+            name: ui
+          vars:
+            ui_application_image_tag: latest
+            ui_postgres_image: >-
+              example.invalid/database@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            ui_postgres_password: test-only
+            ui_health_host: test-ui-public-address
+      rescue:
+        - name: Record that the invalid tag was rejected
+          ansible.builtin.set_fact:
+            ui_invalid_image_tag_rejected: true
+
+    - name: Verify mutable image tags are rejected
+      ansible.builtin.assert:
+        that:
+          - ui_invalid_image_tag_rejected
+          - ui_database_address == 'database-private-address'
+          - ui_history_address == 'history-private-address'
+          - >-
+            ui_history_service_url ==
+            'http://history-private-address:8001'

--- a/infrastructure/ansible/oilscope/platform/roles/ui/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/vars/main.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+ui_compose_service: ui
+ui_runtime_environment: >-
+  {{
+    ui_compose_environment
+    | combine({
+      'APP_IMAGE_TAG': ui_application_image_tag,
+      'POSTGRES_IMAGE': ui_postgres_image,
+      'POSTGRES_PASSWORD': ui_postgres_password,
+      'POSTGRES_USER': ui_postgres_user,
+      'POSTGRES_DB': ui_postgres_name,
+      'DATABASE_HOST': ui_database_address,
+      'DATABASE_PORT': ui_database_port | string,
+      'DATABASE_SSLMODE': ui_database_sslmode,
+      'HISTORY_SERVICE_URL': ui_history_service_url,
+      'UI_BIND_ADDRESS': ui_bind_address | string,
+      'UI_HTTP_PORT': ui_http_port | string,
+      'SESSION_TTL_SECONDS': ui_session_ttl_seconds | string,
+      'SESSION_COOKIE_SECURE': ui_session_cookie_secure | ternary('true', 'false'),
+      'LOG_LEVEL': ui_log_level
+    })
+  }}


### PR DESCRIPTION
## Summary

- Added the Ansible `ui` role for issue #101.
- Resolves Database and History addresses from Ansible inventory.
- Configures the UI runtime environment for the shared Docker Compose deployment.
- Pulls and starts only the `ui` service using `--no-deps`.
- Verifies the public UI `/health` endpoint.
- Keeps PostgreSQL secret injection compatible with the pending `gcp_runtime_secrets` role.

## Validation

- Ansible lint passed.
- YAML lint passed.
- Role validation tests passed.
- No hardcoded service IPs or credentials were added.

## Note

A full GCP deployment was not performed because the runtime secret role and production inventory are not yet available.
