### PR TITLE
Upload deployment secret versions without exposing them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ crash.*.log
 *.pem
 *.key
 !project-config.example.json
+
+# Built Ansible collection artifacts
+infrastructure/ansible/**/*.tar.gz

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -92,9 +92,10 @@ printf '%s' "${DB_PASSWORD_HISTORY}" \
 Note `printf` rather than `echo`: `echo` appends a newline, which becomes part of
 the stored value and then fails an exact comparison somewhere far away from here.
 
-Which environment variable holds which value is not a convention to remember —
-it is the key side of `secret_mappings`. Read it from the configuration rather
-than deriving it from the secret's name.
+Which environment variable the *application* reads is not a convention to
+remember: it is the key side of `secret_mappings`. It is scoped to one VM
+though, so it is not the variable you export when uploading — see
+[Uploading every value at once](#uploading-every-value-at-once).
 
 Generate database passwords with `openssl rand -hex 32`. `-hex` rather than
 `-base64`, because base64 contains `+` and `/`, which have to be percent-encoded
@@ -116,6 +117,83 @@ do, and they hold only `secretAccessor`, only on their own secrets.
 
 Leave the list empty and nobody but a project owner can upload a value, which is
 a reasonable default: it fails closed.
+
+## Uploading every value at once
+
+Doing that by hand for every secret is where a value eventually ends up in the
+wrong place. The `oilscope.platform.secret_versions` role does the whole
+catalog in one pass, taking each value from the environment of the operator who
+runs it. It targets `localhost`: this is an operator task against the Google
+API, not host configuration.
+
+```bash
+ export DB_PASSWORD_ADMIN="$(openssl rand -hex 32)"
+ export DB_PASSWORD_FETCHER="$(openssl rand -hex 32)"
+ export DB_PASSWORD_HISTORY="$(openssl rand -hex 32)"
+ export DB_PASSWORD_UI="$(openssl rand -hex 32)"
+ export OILPRICEAPI_KEY="..."
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json --check
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json
+```
+
+The leading space keeps the export out of the shell history, in a shell
+configured to honour it. `--check` runs every check and uploads nothing; the
+role prints which variable feeds which container before it writes anything.
+
+### Why the variable is not the one the application sees
+
+The unit of upload is the container, so the variable name is derived from the
+container ID with the project prefix dropped — not from the key side of
+`secret_mappings`:
+
+```
+oilscope-dev-db-password-fetcher   ->  DB_PASSWORD_FETCHER
+oilscope-dev-oilpriceapi-key       ->  OILPRICEAPI_KEY
+```
+
+That key is scoped to one VM: `DB_PASSWORD` means the fetcher's password on
+`fetcher` and the history service's password on `history`, and one shell cannot
+hold both under one name. Where dropping the prefix would make two containers
+collide, every container keeps the fully qualified name
+(`OILSCOPE_DEV_DB_PASSWORD_FETCHER`) instead.
+
+### What it guarantees
+
+| | |
+| --- | --- |
+| reads values from | the environment of the process, and nowhere else |
+| passes the payload to gcloud | on stdin, through `--data-file=-` |
+| writes to disk | nothing |
+| prints | container IDs and variable names, never a value |
+
+Every value and every container is checked before the first version is added. A
+missing one fails the play with the full list, before anything is written.
+Half-rotated is the state that costs an evening — one service on the new
+password, three on the old.
+
+The upload task carries `no_log`, so the payload stays out of the Ansible output
+and any callback log at every verbosity, and `stdin_add_newline` is off because
+a trailing newline would become part of the stored value. The task is also
+skipped explicitly in check mode rather than being left to the module: a
+check-mode skip result carries the module arguments, and `-vvv` prints those
+uncensored.
+
+Rotating a single credential:
+
+```bash
+ export DB_PASSWORD_UI="$(openssl rand -hex 32)"
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json \
+  -e '{"secret_versions_only": ["DB_PASSWORD_UI"]}'
+```
+
+Adding a version requires `roles/secretmanager.secretVersionAdder`, so whoever
+runs this does not need to be able to read what is already stored.
 
 ## Rotation
 

--- a/infrastructure/ansible/oilscope/platform/playbooks/upload_secret_versions.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/upload_secret_versions.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Upload deployment secret versions
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: oilscope.platform.secret_versions

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/README.md
@@ -1,0 +1,107 @@
+# Secret versions role
+
+Adds a new Secret Manager version to every container declared in the project
+configuration, taking each value from the environment of the operator running
+the play. It runs on `localhost`: this is an operator task against the Google
+API, not host configuration.
+
+Terraform creates the containers and grants access to them, and never carries a
+payload — see [docs/secrets.md](../../../../../../docs/secrets.md). This role is
+the other half: the payload, and nothing else.
+
+## What it guarantees
+
+- Values are read from the process environment, and from nowhere else. Nothing
+  is written to disk.
+- The payload reaches `gcloud` on stdin through `--data-file=-`, so it never
+  becomes a command argument and cannot appear in `ps` output or a shell
+  history. `stdin_add_newline` is off, because a trailing newline would become
+  part of the stored value.
+- The upload task is marked `no_log`, so the value stays out of the Ansible
+  output and out of any callback log, at every verbosity.
+- Every value and every container is checked before the first version is added.
+  A run either writes all of them or none: half-rotated is the state that
+  leaves one workload on the new credential and the rest on the old one.
+
+Run it with `--check` first. In check mode the role performs every check and
+adds nothing.
+
+## Requirements
+
+`gcloud`, authenticated as a principal holding
+`roles/secretmanager.secretVersionAdder` on the containers. That role permits
+adding a version and not reading one, so rotation does not require access to
+the current value. Terraform grants it from the `secret_version_managers`
+variable.
+
+The containers must already exist: `terraform apply` creates them from the same
+configuration file this role reads.
+
+## Required variables
+
+- `secret_versions_config_file`: path to the project configuration JSON — the
+  same file `project_config_path` points at in Terraform.
+
+## Optional variables
+
+- `secret_versions_project_id`: target project. Falls back to `$GOOGLE_PROJECT`,
+  then to `project_id` in the configuration.
+- `secret_versions_only`: list of container IDs or variable names to upload.
+  Defaults to all of them; use it to rotate one credential.
+- `secret_versions_gcloud`: path to the `gcloud` executable.
+
+## Which variable holds which value
+
+The variable name is derived from the container ID, with the
+`<name_prefix>-<environment>-` prefix dropped while that stays unambiguous:
+
+```
+oilscope-dev-db-password-fetcher   ->  DB_PASSWORD_FETCHER
+oilscope-dev-oilpriceapi-key       ->  OILPRICEAPI_KEY
+```
+
+It is deliberately not the key side of `secret_mappings`. That key is the
+variable the application reads *inside one VM*: `DB_PASSWORD` is the fetcher's
+password on `fetcher` and the history service's password on `history`, and one
+shell cannot hold both under one name. If dropping the prefix would make two
+containers collide, every container keeps the fully qualified name
+(`OILSCOPE_DEV_DB_PASSWORD_FETCHER`) instead.
+
+The role prints the mapping before it uploads anything, so there is nothing to
+guess.
+
+## Example
+
+```bash
+ export DB_PASSWORD_ADMIN="$(openssl rand -hex 32)"
+ export DB_PASSWORD_FETCHER="$(openssl rand -hex 32)"
+ export DB_PASSWORD_HISTORY="$(openssl rand -hex 32)"
+ export DB_PASSWORD_UI="$(openssl rand -hex 32)"
+ export OILPRICEAPI_KEY="..."
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json --check
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json
+```
+
+The leading space keeps the export out of the shell history, in a shell
+configured to honour it.
+
+Rotating one credential:
+
+```bash
+ export DB_PASSWORD_UI="$(openssl rand -hex 32)"
+
+ansible-playbook oilscope.platform.upload_secret_versions \
+  -e secret_versions_config_file=~/configs/oilscope/dev.json \
+  -e '{"secret_versions_only": ["DB_PASSWORD_UI"]}'
+```
+
+Older versions stay until they are destroyed, so an upload is reversible until
+then.
+
+## License
+
+GPL-2.0-or-later

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/defaults/main.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# Project configuration JSON - the same file the Terraform configuration reads.
+secret_versions_config_file: ""
+
+# Target GCP project. Falls back to $GOOGLE_PROJECT, then to project_id in the
+# configuration.
+secret_versions_project_id: ""
+
+# Upload a subset. Entries match a container ID or a variable name.
+secret_versions_only: []
+
+secret_versions_gcloud: gcloud

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+[]

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/meta/main.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Add Secret Manager versions from the operator's environment
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  galaxy_tags:
+    - gcp
+    - secrets
+    - security
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/tasks/main.yml
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Require a project configuration
+  ansible.builtin.assert:
+    that:
+      - secret_versions_config_file | length > 0
+    fail_msg: >-
+      secret_versions_config_file must point at the project configuration JSON,
+      the same file the Terraform configuration reads.
+
+- name: Read the project configuration
+  ansible.builtin.set_fact:
+    secret_versions_config: >-
+      {{ lookup('ansible.builtin.file', secret_versions_config_file) | from_json }}
+
+# The unit of upload is the container. One container is usually read by several
+# workloads, so the mappings are collapsed to (container, workload) pairs first.
+- name: Collect the container and workload pairs
+  ansible.builtin.set_fact:
+    secret_versions_pairs: >-
+      {{ secret_versions_pairs | default([])
+         + (secret_versions_vm.value.secret_mappings | default({}) | dict2items
+            | map(attribute='value') | unique | list
+            | zip_longest([], fillvalue=secret_versions_vm.key) | list) }}
+  loop: "{{ secret_versions_config.vms | dict2items }}"
+  loop_control:
+    loop_var: secret_versions_vm
+    label: "{{ secret_versions_vm.key }}"
+
+- name: Require at least one mapping
+  ansible.builtin.assert:
+    that:
+      - secret_versions_pairs | default([]) | length > 0
+    fail_msg: >-
+      No secret_mappings in {{ secret_versions_config_file }} - nothing to upload.
+
+# The variable name comes from the container ID, not from the key side of
+# secret_mappings: that key is scoped to one VM, so DB_PASSWORD means a
+# different secret on every workload and one shell cannot hold them all.
+- name: Derive a variable name for every container
+  ansible.builtin.set_fact:
+    secret_versions_ids: >-
+      {{ secret_versions_pairs | map(attribute='0') | unique | sort | list }}
+    secret_versions_prefix: >-
+      {{ secret_versions_config.name_prefix }}-{{ secret_versions_config.environment }}-
+
+- name: Prepare the short and the fully qualified variable names
+  ansible.builtin.set_fact:
+    secret_versions_short_names: >-
+      {{ secret_versions_ids
+         | map('regex_replace', '^' ~ (secret_versions_prefix | regex_escape), '')
+         | map('upper') | map('regex_replace', '[^A-Z0-9]', '_') | list }}
+    secret_versions_full_names: >-
+      {{ secret_versions_ids
+         | map('upper') | map('regex_replace', '[^A-Z0-9]', '_') | list }}
+
+# Dropping the project prefix only stays safe while it keeps every name
+# distinct. If two containers would collapse onto one variable, all of them
+# keep the full name: a shorter prompt is not worth writing a value into the
+# wrong container.
+- name: Choose the variable names
+  ansible.builtin.set_fact:
+    secret_versions_variables: >-
+      {{ secret_versions_short_names
+         if (secret_versions_short_names | unique | length)
+            == (secret_versions_short_names | length)
+         else secret_versions_full_names }}
+
+- name: Build the upload catalog
+  ansible.builtin.set_fact:
+    secret_versions_catalog: >-
+      {{ secret_versions_catalog | default([]) + [{
+           'secret_id': secret_versions_entry.0,
+           'variable': secret_versions_entry.1,
+           'read_by': secret_versions_pairs
+                      | selectattr('0', 'eq', secret_versions_entry.0)
+                      | map(attribute='1') | sort | list
+         }] }}
+  loop: "{{ secret_versions_ids | zip(secret_versions_variables) | list }}"
+  loop_control:
+    loop_var: secret_versions_entry
+    label: "{{ secret_versions_entry.0 }}"
+
+- name: Keep only the requested containers
+  ansible.builtin.set_fact:
+    secret_versions_catalog: >-
+      {{ secret_versions_catalog
+         | selectattr('secret_id', 'in', secret_versions_only)
+         | list
+         + (secret_versions_catalog
+            | rejectattr('secret_id', 'in', secret_versions_only)
+            | selectattr('variable', 'in', secret_versions_only)
+            | list) }}
+  when: secret_versions_only | length > 0
+
+- name: Require the requested containers to exist in the configuration
+  ansible.builtin.assert:
+    that:
+      - secret_versions_catalog | length == secret_versions_only | length
+    fail_msg: >-
+      secret_versions_only names something that is not in
+      {{ secret_versions_config_file }}. Requested
+      {{ secret_versions_only | join(', ') }}; matched
+      {{ secret_versions_catalog | map(attribute='secret_id') | join(', ') }}.
+  when: secret_versions_only | length > 0
+
+- name: Show which variable feeds which container
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.variable }} -> {{ item.secret_id }}
+      (read by {{ item.read_by | join(', ') }})
+  loop: "{{ secret_versions_catalog }}"
+  loop_control:
+    label: "{{ item.secret_id }}"
+
+- name: Resolve the target project
+  ansible.builtin.set_fact:
+    secret_versions_project: >-
+      {{ secret_versions_project_id
+         | default(lookup('ansible.builtin.env', 'GOOGLE_PROJECT'), true)
+         | default(secret_versions_config.project_id | default(''), true) }}
+
+- name: Require a target project
+  ansible.builtin.assert:
+    that:
+      - secret_versions_project | length > 0
+    fail_msg: >-
+      No target project. Set secret_versions_project_id, export GOOGLE_PROJECT,
+      or add project_id to {{ secret_versions_config_file }}.
+
+# Everything is checked before anything is written. A value that turns out to
+# be missing halfway through leaves some workloads on the new credential and
+# some on the old one, which is worse than not having started.
+- name: Find values that are not in the environment
+  ansible.builtin.set_fact:
+    secret_versions_absent: >-
+      {{ secret_versions_absent | default([])
+         + ([item.variable]
+            if lookup('ansible.builtin.env', item.variable) | length == 0
+            else []) }}
+  loop: "{{ secret_versions_catalog }}"
+  loop_control:
+    label: "{{ item.variable }}"
+
+- name: Require every value before anything is uploaded
+  ansible.builtin.assert:
+    that:
+      - secret_versions_absent | default([]) | length == 0
+    fail_msg: >-
+      Not set, or empty, in this environment:
+      {{ secret_versions_absent | default([]) | join(', ') }}. Nothing was
+      uploaded. Export them in the shell that runs this play - start the line
+      with a space so it stays out of the history - and do not keep them in a
+      file.
+
+- name: Look for the containers
+  ansible.builtin.command:
+    argv:
+      - "{{ secret_versions_gcloud }}"
+      - secrets
+      - describe
+      - "{{ item.secret_id }}"
+      - "--project={{ secret_versions_project }}"
+      - "--format=value(name)"
+  loop: "{{ secret_versions_catalog }}"
+  loop_control:
+    label: "{{ item.secret_id }}"
+  register: secret_versions_describe
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+# secretVersionAdder allows adding a version without reading the metadata, so a
+# permission error is not proof that the container is missing.
+- name: Require every container to exist
+  ansible.builtin.assert:
+    that:
+      - secret_versions_undefined | length == 0
+    fail_msg: >-
+      These containers do not exist in {{ secret_versions_project }}:
+      {{ secret_versions_undefined | join(', ') }}. Terraform creates them from
+      the same configuration - run terraform apply first. Nothing was uploaded.
+  vars:
+    secret_versions_undefined: >-
+      {{ secret_versions_describe.results
+         | rejectattr('rc', 'eq', 0)
+         | rejectattr('stderr', 'search', 'PERMISSION_DENIED')
+         | map(attribute='item.secret_id') | list }}
+
+# --data-file=- takes the payload from stdin, so it never becomes a command
+# argument and cannot appear in ps output or a shell history. no_log keeps it
+# out of the Ansible output and any callback log, and stdin_add_newline is off
+# because a trailing newline would become part of the stored value.
+- name: Add a new version to every container
+  ansible.builtin.command:
+    argv:
+      - "{{ secret_versions_gcloud }}"
+      - secrets
+      - versions
+      - add
+      - "{{ item.secret_id }}"
+      - "--project={{ secret_versions_project }}"
+      - "--data-file=-"
+      - "--format=value(name)"
+    stdin: "{{ lookup('ansible.builtin.env', item.variable) }}"
+    stdin_add_newline: false
+  loop: "{{ secret_versions_catalog }}"
+  loop_control:
+    label: "{{ item.secret_id }}"
+  register: secret_versions_added
+  changed_when: true
+  no_log: true
+  # Not check_mode - a skipped-in-check-mode result carries the module
+  # arguments, and at -vvv Ansible prints those uncensored even under no_log.
+  when: not ansible_check_mode
+
+- name: Report the new versions
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.item.secret_id }} <- ${{ item.item.variable }}
+      (version {{ item.stdout | trim | regex_replace('^.*/', '') }})
+  loop: "{{ secret_versions_added.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.secret_id }}"
+  when: not ansible_check_mode

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/tests/inventory
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/tests/test.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Validate the secret_versions role
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include the role without a configuration file
+      ansible.builtin.include_role:
+        name: secret_versions
+      register: secret_versions_no_config
+      ignore_errors: true
+
+    - name: Verify a missing configuration is rejected
+      ansible.builtin.assert:
+        that:
+          - secret_versions_no_config is failed


### PR DESCRIPTION
Terraform creates the containers and grants access; it never carries a payload. Filling them was a manual gcloud invocation per secret, which is where a value eventually reaches the wrong place.

The oilscope.platform.secret_versions role does the whole catalog against localhost - an operator task on the Google API, not host configuration:

- Values are read from the operator's environment and from nowhere else. The variable is derived from the container ID rather than from the key side of secret_mappings: that key is scoped to one VM - DB_PASSWORD is the fetcher's password on fetcher and the history service's on history - so one shell cannot hold them all. The role prints the mapping first.
- The payload reaches gcloud on stdin through --data-file=-, so it never becomes a command argument and cannot appear in ps output or a shell history. stdin_add_newline is off, because a trailing newline would be stored as part of the value. Nothing is written to disk.
- The upload task carries no_log, and is skipped explicitly in check mode rather than left to the module: a check-mode skip result carries the module arguments, and -vvv prints those uncensored even under no_log.
- Every value and every container is checked before the first version is added, so a run writes all of them or none. Half-rotated leaves one workload on the new credential and the rest on the old one.

Run it with --check for a dry run; secret_versions_only takes a single container, by ID or by variable name, for rotating one credential.

Closes #87