### PR TITLE
Point the VM module at the Compose file that still exists

### DIFF
--- a/infrastructure/terraform/modules/vm/locals.tf
+++ b/infrastructure/terraform/modules/vm/locals.tf
@@ -5,6 +5,9 @@ locals {
     image_sha           = var.image_sha
     docker_version      = var.docker_version
     run_script          = file("${path.module}/templates/run.sh")
-    compose_deployment  = file("${path.module}/../../../docker/compose.deployment.yaml")
+    # Single source of truth for the deployment Compose file. It moved into the
+    # compose_project role in #106; the name ends in .j2 by role convention, but
+    # the file holds no Jinja - only the shell interpolation Compose expands.
+    compose_deployment = file("${path.module}/../../../ansible/oilscope/platform/roles/compose_project/templates/compose.deployment.yaml.j2")
   })
 }


### PR DESCRIPTION
#106 moved infrastructure/docker/compose.deployment.yaml into the compose_project role as compose.deployment.yaml.j2, but modules/vm/locals.tf still reads the old path through file(). Terraform plan, apply and validate all fail on develop as a result.

The moved file is byte-identical to the deleted one and contains no Jinja - only the shell interpolation Compose itself expands - so the module can read it where it now lives, and there is one copy rather than two that drift.

CI did not catch this: the Terraform job only runs when something under infrastructure/terraform/ changes, and the deleted file was outside that directory. Widening that filter is a separate change.

This restores the previous behaviour and is not a decision about where the Compose file belongs. If cloud-init should stop shipping it now that the compose_project role deploys it, that is worth its own issue.