### PR TITLE
Feature/issue 93 ansible inventory plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ crash.*.log
 
 # Built Ansible collection artifacts
 infrastructure/ansible/**/*.tar.gz
+
+*.local.gcp.yml

--- a/infrastructure/ansible/inventory/README.md
+++ b/infrastructure/ansible/inventory/README.md
@@ -1,0 +1,99 @@
+# Inventory
+
+`oilscope.gcp.yml` builds the deployment inventory from live Compute Engine
+state using the upstream `google.cloud.gcp_compute` plugin, so a
+`terraform apply` that replaces a VM or changes an address is picked up without
+editing a host list.
+
+It is dynamic in the Ansible sense — recomputed on every run. Nothing polls in
+the background; `cache_timeout` only bounds how long a previous API response is
+reused.
+
+## Setup
+
+All three steps are required. None of them is optional, and skipping one
+produces a failure that does not name the missing piece:
+
+```sh
+pip install -r infrastructure/ansible/requirements.txt
+ansible-galaxy collection install -r infrastructure/ansible/requirements.yml
+gcloud auth application-default login
+```
+
+`requirements.yml` installs the `google.cloud` collection, which provides the
+`gcp_compute` plugin itself. `requirements.txt` installs the Python libraries
+that plugin imports at run time — `google-auth` and `requests`.
+
+The two are separate on purpose: `ansible-galaxy` installs collections, never
+Python packages. The collection does ship its own `requirements.txt` naming the
+same libraries, but nothing ever executes it — installing them is the caller's
+job.
+
+Both failures look like an inventory that simply does not exist, so they are
+worth recognising. Without the collection:
+
+```
+[WARNING]: Failed to parse inventory with 'auto' plugin: inventory config
+'.../oilscope.gcp.yml' specifies unknown plugin 'google.cloud.gcp_compute'
+```
+
+With the collection but without the Python libraries — the plugin refuses
+before reading a single option:
+
+```
+[WARNING]: Failed to parse inventory with 'auto' plugin: gce inventory plugin
+cannot start: Failed to import the required Python library (google-auth) on
+<host>'s Python <interpreter>.
+```
+
+In both cases Ansible then reports "No inventory was parsed, only implicit
+localhost is available" and every play matches nothing.
+
+Then edit `projects`, `zones` and the `filters` labels in `oilscope.gcp.yml` to
+match the project configuration JSON for the environment being deployed. The
+plugin cannot read that JSON, and Jinja is not evaluated in this file, so those
+values cannot be derived automatically. Keeping one copy of the file per
+environment is the usual way to avoid editing it before each run.
+
+## Usage
+
+```sh
+ansible-inventory -i infrastructure/ansible/inventory/oilscope.gcp.yml --graph
+```
+
+A misconfigured `projects` or `filters` value produces an **empty inventory and
+exit status 0**, not an error — the plugin swallows the API failure. If a
+playbook reports "no hosts matched", check the inventory with the command above
+before looking anywhere else.
+
+## Groups
+
+Terraform labels every VM with `role=<role>`, which `keyed_groups` turns into
+the `bastion`, `database`, `history`, `fetcher` and `ui` groups the deployment
+roles expect. Everything except the bastion also joins `workloads`.
+
+Note that the group name comes from the `role` label, not from the key in the
+project configuration JSON: `vms.infra` has `role: database` and therefore
+lands in the `database` group, which is what the `ui` role looks for.
+
+## Host variables
+
+`internal_ip` is set on every host. This is a contract, not a convenience: the
+`ui` role resolves its Database and History peers through that exact variable
+name. Also set: `public_ip`, `oilscope_role`, `ansible_host`, `ansible_port`.
+
+## SSH
+
+The bastion is reached on its external address at the non-default port; every
+workload is reached on its internal address at port 22, through a
+`ProxyCommand` defined in `group_vars/workloads.yml`.
+
+The non-default port belongs to the bastion alone — the Terraform workload
+firewall rule opens 22 and nothing else, so applying that port globally would
+break every workload connection.
+
+`ansible_user` (in `group_vars/all.yml`) defaults to the controller's own login
+name, because that is the name a key added through `gcloud compute ssh` is
+registered under in GCP project metadata. Everyone connects as themselves and
+no name is committed. Override for one run with `OILSCOPE_SSH_USER`, or edit
+`group_vars/all.yml` to pin a single shared account.

--- a/infrastructure/ansible/inventory/group_vars/all.yml
+++ b/infrastructure/ansible/inventory/group_vars/all.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# google.cloud.gcp_compute has no option for the SSH account, so it is resolved
+# here instead.
+#
+# The default is the controller's own login name, because that is the name a
+# public key added through `gcloud compute ssh` is registered under in GCP
+# project metadata. Everyone therefore connects as themselves and no one's
+# name is committed to the repository.
+#
+# Override for a single run with OILSCOPE_SSH_USER, or replace the whole
+# expression with a shared account such as "deploy".
+ansible_user: >-
+  {{ lookup('ansible.builtin.env', 'OILSCOPE_SSH_USER')
+     | default(lookup('ansible.builtin.env', 'USER'), true) }}
+
+# The private key whose public half reaches the VMs. Terraform installs the
+# `ssh_users` map from the project configuration JSON as instance metadata, so
+# the account above must appear in that map - or, while project-wide keys are
+# still accepted, be the one `gcloud compute ssh` registered.
+#
+# The default matches the key gcloud generates on first use. Without this
+# setting SSH offers only its own default identities and every host answers
+# "Permission denied (publickey)". Override with OILSCOPE_SSH_KEY.
+ansible_ssh_private_key_file: >-
+  {{ lookup('ansible.builtin.env', 'OILSCOPE_SSH_KEY')
+     | default(lookup('ansible.builtin.env', 'HOME')
+               ~ '/.ssh/google_compute_engine', true) }}
+
+# Every VM is created fresh by Terraform, so its host key is new and absent
+# from known_hosts. accept-new records it on first contact but still refuses a
+# key that changed afterwards, unlike StrictHostKeyChecking=no.
+#
+# group_vars/workloads.yml extends this with the ProxyCommand rather than
+# replacing it, so the settings apply to the outer connection as well as to
+# the jump.
+#
+# IdentitiesOnly matches the bastion's sshd hardening, which sets
+# MaxAuthTries: without it SSH offers every key in the agent first and can
+# exhaust the allowed attempts before reaching the one that works.
+oilscope_ssh_base_args: >-
+  -o StrictHostKeyChecking=accept-new
+  -o IdentitiesOnly=yes
+ansible_ssh_common_args: "{{ oilscope_ssh_base_args }}"

--- a/infrastructure/ansible/inventory/group_vars/workloads.yml
+++ b/infrastructure/ansible/inventory/group_vars/workloads.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# The ProxyCommand cannot live in the plugin's `compose` block: that is
+# evaluated per host and has no way to read another host's address. group_vars
+# is evaluated later, once the whole inventory exists, so the bastion can be
+# looked up here.
+#
+# Both values are taken from the bastion's own host variables rather than
+# repeated, so the port stays defined in exactly one place - the `compose`
+# block of oilscope.gcp.yml.
+oilscope_bastion_address: "{{ hostvars[groups['bastion'][0]].ansible_host }}"
+oilscope_bastion_ssh_port: "{{ hostvars[groups['bastion'][0]].ansible_port }}"
+
+# The ProxyCommand is a separate ssh process. It inherits neither
+# ansible_ssh_private_key_file nor --private-key, so the identity has to be
+# passed to it explicitly or the jump hop fails with "Permission denied".
+ansible_ssh_common_args: >-
+  {{ oilscope_ssh_base_args }}
+  -o ProxyCommand="ssh -W %h:%p -q
+  -p {{ oilscope_bastion_ssh_port }}
+  -i {{ ansible_ssh_private_key_file }}
+  {{ oilscope_ssh_base_args }}
+  {{ ansible_user }}@{{ oilscope_bastion_address }}"

--- a/infrastructure/ansible/inventory/oilscope.gcp.yml
+++ b/infrastructure/ansible/inventory/oilscope.gcp.yml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# Dynamic inventory of the OilScope VMs, built from live Compute Engine state.
+#
+# "Dynamic" means the inventory is rebuilt every time a playbook runs. Nothing
+# polls in the background; the cache below only avoids repeating the same API
+# call within its timeout.
+#
+# The filename must end in gcp.yml, gcp.yaml, gcp_compute.yml or
+# gcp_compute.yaml, otherwise google.cloud.gcp_compute will not claim it.
+plugin: google.cloud.gcp_compute
+
+# These four settings duplicate the project configuration JSON, because this
+# plugin cannot read it. Jinja is not evaluated in this file either - the
+# literal text would be sent to the API - so environment variables are not an
+# option. Keep the values in step with the JSON for the environment being
+# deployed, or keep one copy of this file per environment.
+#
+#   projects[0]        <- project_id
+#   zones[0]           <- zone
+#   labels.application <- name_prefix
+#   labels.environment <- environment
+projects:
+  - example-project-12345
+
+zones:
+  - europe-west1-b
+
+filters:
+  - labels.application = oilscope
+  - labels.environment = dev
+
+# Application Default Credentials. Run this once on the controller:
+#   gcloud auth application-default login
+auth_kind: application
+
+# Name hosts after the instance. The plugin otherwise prefers public_ip, which
+# would name most hosts after an address they do not have.
+hostnames:
+  - name
+
+# The plugin copies every field of the instance JSON into host variables,
+# including "name" and "tags", which Ansible reserves. Without a prefix each
+# run warns about them. The prefix does not affect the expressions below:
+# compose, groups and keyed_groups read the raw API response, not these
+# variables.
+vars_prefix: gcp_
+
+# Terraform labels every VM with role=<role>, which yields the bastion,
+# database, history, fetcher and ui groups the deployment roles expect. The
+# empty prefix and separator keep the group name equal to the label value.
+keyed_groups:
+  - key: labels.role
+    prefix: ''
+    separator: ''
+
+# Parent group for everything reached through the bastion.
+# group_vars/workloads.yml attaches the ProxyCommand to it.
+groups:
+  workloads: labels.role is defined and labels.role != 'bastion'
+
+compose:
+  # internal_ip is part of the contract with the deployment roles: the ui role
+  # resolves its Database and History peers through this exact variable name.
+  internal_ip: networkInterfaces[0].networkIP
+  public_ip: >-
+    networkInterfaces[0].accessConfigs[0].natIP
+    if networkInterfaces[0].accessConfigs | default([])
+    else ''
+
+  # The bastion is reached on its external address; every workload is reached
+  # on its internal one, through the bastion. The ui VM also has an external
+  # address, but that one is for end users, not for SSH.
+  ansible_host: >-
+    networkInterfaces[0].accessConfigs[0].natIP
+    if labels.role | default('') == 'bastion'
+    else networkInterfaces[0].networkIP
+
+  # Only the bastion moves off port 22. The Terraform workload firewall rule
+  # opens 22 and nothing else, so setting a non-default port globally would
+  # break every workload connection. Keep this in step with the bastion's
+  # ssh_port in the project configuration JSON.
+  ansible_port: 2222 if labels.role | default('') == 'bastion' else 22
+
+  oilscope_role: labels.role | default('')
+
+cache: true
+cache_plugin: ansible.builtin.jsonfile
+cache_connection: ~/.cache/oilscope-inventory
+cache_timeout: 300

--- a/infrastructure/ansible/requirements.txt
+++ b/infrastructure/ansible/requirements.txt
@@ -1,0 +1,11 @@
+# Controller-side Python requirements for the OilScope Ansible tooling.
+#
+# The google.cloud.gcp_compute inventory plugin used by
+# inventory/oilscope.gcp.yml talks to the Compute Engine API through these
+# libraries, authenticating with Application Default Credentials:
+#
+#     pip install -r infrastructure/ansible/requirements.txt
+#     gcloud auth application-default login
+#
+google-auth>=2.0.0
+requests>=2.25.0

--- a/infrastructure/ansible/requirements.yml
+++ b/infrastructure/ansible/requirements.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+# Ansible collections the controller needs, beyond this repository's own
+# oilscope.platform collection.
+#
+#   ansible-galaxy collection install -r infrastructure/ansible/requirements.yml
+collections:
+  # Provides the gcp_compute inventory plugin used by inventory/oilscope.gcp.yml.
+  - name: google.cloud
+    version: ">=1.14.0"


### PR DESCRIPTION
Closes #93 

- Adds a dynamic inventory built from live Compute Engine state via `google.cloud.gcp_compute`.
- Groups hosts by the `role` label Terraform applies to every VM, yielding `bastion`, `database`, `history`, `fetcher` and `ui`.
- Exposes `internal_ip` on every host.
- Routes workload SSH through the bastion with a generated `ProxyCommand`. The non-default port applies to the bastion only; workloads stay on 22, the sole port the workload firewall rule opens.
- Defaults `ansible_user` to the controller's login name, so each engineer connects as themselves and no name is committed. Override with `OILSCOPE_SSH_USER`.
- Adds `requirements.yml` (the `google.cloud` collection) and keeps `requirements.txt` (its Python libraries) — `ansible-galaxy` never installs Python packages, and the plugin refuses to start without them.