### PR TITLE
compose_project fix

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Select image SHA from project configuration
   ansible.builtin.set_fact:
     compose_project_image_sha: >-
-      {{ compose_project_config.workloads[compose_project_workload].image_tag
+      {{ compose_project_config.registry.image_sha
          | default('') }}
 
 - name: Create application directory


### PR DESCRIPTION
compose_project reads workloads[name].image_tag from the config JSON, this field doesn't exist anymore.