### PR TITLE
Remove config_version from the code

### DIFF
--- a/infrastructure/terraform/project-config.schema.json
+++ b/infrastructure/terraform/project-config.schema.json
@@ -1,11 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Project Configuration",
-  "description": "Versioned contract for non-secret Terraform project configuration.",
+  "description": "Contract for non-secret Terraform project configuration.",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "config_version",
     "project_id",
     "environment",
     "region",

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -7,11 +7,6 @@ variable "project_config_path" {
     condition     = fileexists(var.project_config_path)
     error_message = "project_config_path must point to an existing file."
   }
-
-  validation {
-    condition     = try(jsondecode(file(var.project_config_path)).config_version == 3, false)
-    error_message = "project_config_path must contain valid JSON using config_version 3."
-  }
 }
 
 variable "secret_version_managers" {


### PR DESCRIPTION
- Removed config_version from the schema and project configuration json file.
- Removed Terraform’s version-specific validation for config_version.