### PR TITLE
Add Database and History deployment playbooks

### DIFF
--- a/infrastructure/ansible/oilscope/platform/playbooks/database.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/database.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Deploy Database
+  hosts: database
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: oilscope.platform.host_baseline
+
+    - role: oilscope.platform.docker_engine
+
+    - role: oilscope.platform.compose_project
+      vars:
+        compose_project_config_path: "{{ project_config_path }}"
+        compose_project_workload: "{{ oilscope_role }}"
+
+    - role: oilscope.platform.database
+      vars:
+        database_postgres_image: >-
+          {{
+            compose_project_config.registry.repository
+            ~ '/database:'
+            ~ compose_project_config.registry.image_sha
+          }}
+        database_application_image_tag: >-
+          {{ compose_project_config.registry.image_sha }}

--- a/infrastructure/ansible/oilscope/platform/playbooks/history.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/history.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Deploy History
+  hosts: history
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: oilscope.platform.host_baseline
+
+    - role: oilscope.platform.docker_engine
+
+    - role: oilscope.platform.compose_project
+      vars:
+        compose_project_config_path: "{{ project_config_path }}"
+        compose_project_workload: "{{ oilscope_role }}"
+
+    - role: oilscope.platform.history
+      vars:
+        history_application_image_tag: >-
+          {{ compose_project_config.registry.image_sha }}
+        history_postgres_image: >-
+          {{
+            compose_project_config.registry.repository
+            ~ '/database:'
+            ~ compose_project_config.registry.image_sha
+          }}


### PR DESCRIPTION
## Summary
- add a Database deployment playbook
- add a History deployment playbook
- apply host baseline, Docker Engine, and Compose project roles before service deployment
- pass registry image configuration from the project config into the service roles

## Validation
- `yamllint` passes for both playbooks
- `ansible-playbook --syntax-check` passes for both playbooks