### PR TITLE
Create the Ansible bastion role

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/bastion/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/README.md
@@ -1,0 +1,44 @@
+# Bastion
+
+Configures the OilScope bastion SSH daemon with the port declared at
+`vms.bastion.ssh_port` in the non-secret project configuration JSON. The role
+keeps public-key authentication and TCP forwarding enabled while disabling
+password, keyboard-interactive and root login.
+
+The role manages only
+`/etc/ssh/sshd_config.d/00-oilscope-bastion.conf`. It validates the complete
+daemon configuration with `sshd -t` before restarting SSH. On Ubuntu systems
+where `ssh.socket` is active, the handler reloads systemd and restarts the
+socket so its listener follows the configured port; otherwise it restarts
+`ssh.service`.
+
+## Requirements
+
+- Ansible Core 2.16 or newer.
+- An Ubuntu host with Python and OpenSSH Server available.
+- An SSH user permitted to use privilege escalation.
+- Controller access to both the current and configured SSH ports while the
+  role changes the listener.
+
+## Variables
+
+- `bastion_project_config_path`: controller-side path to project config JSON;
+  defaults to the shared `project_config_path` extra variable.
+- `bastion_sshd_drop_in_dir` and `bastion_sshd_drop_in_path`: managed SSH
+  drop-in locations.
+- `bastion_ssh_connect_timeout`, `bastion_ssh_connect_retries` and
+  `bastion_ssh_connect_delay`: controller-side reachability check settings.
+
+## Usage
+
+```yaml
+---
+- name: Configure the bastion
+  hosts: bastion
+  become: true
+  roles:
+    - role: oilscope.platform.bastion
+```
+
+Run the collection bootstrap playbook for a fresh VM so Ansible connects to
+the image's initial SSH port before this role activates the configured port.

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/defaults/main.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+bastion_project_config_path: "{{ project_config_path | default('') }}"
+bastion_sshd_drop_in_dir: /etc/ssh/sshd_config.d
+bastion_sshd_drop_in_path: >-
+  {{ bastion_sshd_drop_in_dir }}/00-oilscope-bastion.conf
+bastion_ssh_connect_timeout: 5
+bastion_ssh_connect_retries: 12
+bastion_ssh_connect_delay: 5

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/handlers/main.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Reload systemd for the SSH socket
+  become: true
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  listen: Restart bastion SSH
+
+- name: Restart the SSH socket
+  become: true
+  ansible.builtin.systemd_service:
+    name: ssh.socket
+    state: restarted
+  when: bastion_ssh_socket.rc == 0
+  listen: Restart bastion SSH
+
+- name: Restart the SSH service
+  become: true
+  ansible.builtin.systemd_service:
+    name: ssh.service
+    state: restarted
+  when: bastion_ssh_socket.rc != 0
+  listen: Restart bastion SSH

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/meta/main.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Secure SSH access through the OilScope bastion
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - bastion
+    - infrastructure
+    - ssh
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tasks/main.yml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Read the project configuration
+  ansible.builtin.set_fact:
+    bastion_project_config: >-
+      {{ lookup('ansible.builtin.file', bastion_project_config_path) | from_json }}
+
+- name: Record the configured bastion SSH port
+  ansible.builtin.set_fact:
+    bastion_ssh_port: "{{ bastion_project_config.vms.bastion.ssh_port | int }}"
+
+- name: Check whether the SSH socket is active
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - is-active
+      - --quiet
+      - ssh.socket
+  register: bastion_ssh_socket
+  changed_when: false
+  failed_when: false
+
+- name: Create the SSH daemon drop-in directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ bastion_sshd_drop_in_dir }}"
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+
+- name: Install the bastion SSH configuration
+  become: true
+  ansible.builtin.template:
+    src: 00-oilscope-bastion.conf.j2
+    dest: "{{ bastion_sshd_drop_in_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    validate: /usr/sbin/sshd -t -f %s
+  notify: Restart bastion SSH
+
+- name: Validate the complete SSH daemon configuration
+  become: true
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/sshd
+      - -t
+  changed_when: false
+
+- name: Read and verify the effective SSH daemon configuration
+  become: true
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/sshd
+      - -T
+  register: bastion_sshd_effective_config
+  changed_when: false
+  failed_when: >-
+    bastion_sshd_effective_config.rc != 0
+    or (bastion_sshd_effective_config.stdout_lines
+        | select('match', '^port ') | list)
+       != ['port ' ~ (bastion_ssh_port | string)]
+    or 'pubkeyauthentication yes' not in bastion_sshd_effective_config.stdout_lines
+    or 'passwordauthentication no' not in bastion_sshd_effective_config.stdout_lines
+    or 'kbdinteractiveauthentication no' not in bastion_sshd_effective_config.stdout_lines
+    or 'permitemptypasswords no' not in bastion_sshd_effective_config.stdout_lines
+    or 'permitrootlogin no' not in bastion_sshd_effective_config.stdout_lines
+    or 'allowtcpforwarding yes' not in bastion_sshd_effective_config.stdout_lines
+    or 'allowagentforwarding no' not in bastion_sshd_effective_config.stdout_lines
+    or 'gatewayports no' not in bastion_sshd_effective_config.stdout_lines
+    or 'x11forwarding no' not in bastion_sshd_effective_config.stdout_lines
+    or 'permittunnel no' not in bastion_sshd_effective_config.stdout_lines
+
+- name: Apply pending SSH handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for SSH on the configured bastion port
+  ansible.builtin.wait_for:
+    host: "{{ ansible_host }}"
+    port: "{{ bastion_ssh_port }}"
+    connect_timeout: "{{ bastion_ssh_connect_timeout }}"
+    delay: "{{ bastion_ssh_connect_delay }}"
+    timeout: >-
+      {{ bastion_ssh_connect_retries * bastion_ssh_connect_delay }}
+    state: started
+  delegate_to: localhost
+  become: false
+  changed_when: false

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/templates/00-oilscope-bastion.conf.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/templates/00-oilscope-bastion.conf.j2
@@ -1,0 +1,12 @@
+# Managed by oilscope.platform.bastion.
+Port {{ bastion_ssh_port }}
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin no
+AllowTcpForwarding yes
+AllowAgentForwarding no
+GatewayPorts no
+X11Forwarding no
+PermitTunnel no

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tests/inventory
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Supply a disposable Ubuntu host through an external inventory.
+[bastion_test]

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tests/project-config.json.example
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tests/project-config.json.example
@@ -1,0 +1,8 @@
+{
+  "vms": {
+    "bastion": {
+      "role": "bastion",
+      "ssh_port": 2222
+    }
+  }
+}

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tests/test.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Test the bastion role
+  hosts: bastion_test
+  become: true
+  roles:
+    - role: oilscope.platform.bastion
+      vars:
+        bastion_project_config_path: >-
+          {{ playbook_dir }}/project-config.json.example


### PR DESCRIPTION
Implements an Ansible role for secure and idempotent bastion configuration.
- Configures the SSH port and access policy.
- Hardens the OpenSSH service.
- Verifies the effective SSH configuration.
- Adds role tests and documentation.
Closes #132.