### PR TITLE
Feature/133 bastion bootstrap

### DIFF
--- a/infrastructure/ansible/inventory/README.md
+++ b/infrastructure/ansible/inventory/README.md
@@ -58,7 +58,10 @@ environment is the usual way to avoid editing it before each run.
 ## Usage
 
 ```sh
-ansible-inventory -i infrastructure/ansible/inventory/oilscope.gcp.yml --graph
+ansible-inventory \
+  -i infrastructure/ansible/inventory/oilscope.gcp.yml \
+  -e project_config_path=/absolute/path/project-config.json \
+  --graph
 ```
 
 A misconfigured `projects` or `filters` value produces an **empty inventory and
@@ -84,13 +87,24 @@ name. Also set: `public_ip`, `oilscope_role`, `ansible_host`, `ansible_port`.
 
 ## SSH
 
-The bastion is reached on its external address at the non-default port; every
-workload is reached on its internal address at port 22, through a
-`ProxyCommand` defined in `group_vars/workloads.yml`.
+The bastion is reached on its external address at the port read from
+`vms.bastion.ssh_port` in the project config by `group_vars/bastion.yml`.
+Every workload is reached on its internal address at port 22, through a
+`ProxyCommand` defined in `group_vars/workloads.yml`. Pass the absolute project
+config path on every inventory, ad-hoc and playbook command.
 
 The non-default port belongs to the bastion alone — the Terraform workload
 firewall rule opens 22 and nothing else, so applying that port globally would
 break every workload connection.
+
+The Terraform startup script enables the configured port before Ansible runs.
+Run the collection bootstrap playbook to apply and verify the same SSH policy:
+
+```sh
+ansible-playbook oilscope.platform.bootstrap_bastion \
+  -i infrastructure/ansible/inventory/oilscope.gcp.yml \
+  -e project_config_path=/absolute/path/project-config.json
+```
 
 `ansible_user` (in `group_vars/all.yml`) defaults to the controller's own login
 name, because that is the name a key added through `gcloud compute ssh` is

--- a/infrastructure/ansible/inventory/group_vars/bastion.yml
+++ b/infrastructure/ansible/inventory/group_vars/bastion.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+bastion_ssh_port: >-
+  {{ (lookup('ansible.builtin.file', project_config_path) | from_json)
+     .vms.bastion.ssh_port | int }}
+
+ansible_port: "{{ bastion_ssh_port }}"

--- a/infrastructure/ansible/inventory/oilscope.gcp.yml
+++ b/infrastructure/ansible/inventory/oilscope.gcp.yml
@@ -39,8 +39,6 @@ compose:
     if labels.role | default('') == 'bastion'
     else networkInterfaces[0].networkIP
 
-  ansible_port: 2222 if labels.role | default('') == 'bastion' else 22
-
   oilscope_role: labels.role | default('')
 
 cache: true

--- a/infrastructure/ansible/oilscope/platform/playbooks/bootstrap_bastion.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/bootstrap_bastion.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Configure the bastion
+  hosts: bastion
+  become: true
+  gather_facts: false
+  roles:
+    - role: oilscope.platform.bastion
+  post_tasks:
+    - name: Check the SSH connection
+      ansible.builtin.ping:
+      changed_when: false

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/README.md
@@ -1,0 +1,27 @@
+# Bastion
+
+Configures SSH access to the bastion. The port comes from
+`vms.bastion.ssh_port` in the project config.
+
+## Requirements
+
+- Ubuntu with OpenSSH Server.
+- Privilege escalation on the target host.
+
+## Variables
+
+- `bastion_ssh_port`: SSH port; defaults to `ansible_port`.
+- `bastion_sshd_drop_in_path`: managed SSH drop-in location.
+
+## Usage
+
+```yaml
+---
+- name: Configure the bastion
+  hosts: bastion
+  become: true
+  roles:
+    - role: oilscope.platform.bastion
+```
+
+Terraform enables the configured port before this role runs.

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/defaults/main.yml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+bastion_ssh_port: "{{ ansible_port }}"
+bastion_sshd_drop_in_path: /etc/ssh/sshd_config.d/00-oilscope-bastion.conf

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/handlers/main.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Restart SSH
+  become: true
+  ansible.builtin.systemd_service:
+    name: >-
+      {{ 'ssh.socket' if bastion_ssh_socket.rc == 0 else 'ssh.service' }}
+    daemon_reload: true
+    state: restarted
+  listen: Restart bastion SSH

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/meta/main.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Secure SSH access through the OilScope bastion
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - bastion
+    - infrastructure
+    - ssh
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tasks/main.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Check the SSH socket
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - is-active
+      - --quiet
+      - ssh.socket
+  register: bastion_ssh_socket
+  changed_when: false
+  failed_when: false
+
+- name: Create the SSH daemon drop-in directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ bastion_sshd_drop_in_path | dirname }}"
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+
+- name: Install the bastion SSH configuration
+  become: true
+  ansible.builtin.template:
+    src: 00-oilscope-bastion.conf.j2
+    dest: "{{ bastion_sshd_drop_in_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    validate: /usr/sbin/sshd -t -f %s
+  notify: Restart bastion SSH
+
+- name: Check the SSH configuration
+  become: true
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/sshd
+      - -T
+  register: bastion_sshd_effective_config
+  changed_when: false
+  failed_when: >-
+    bastion_sshd_effective_config.rc != 0
+    or bastion_sshd_expected
+       | difference(bastion_sshd_effective_config.stdout_lines)
+       | length > 0
+    or bastion_sshd_effective_config.stdout_lines
+       | select('match', '^port ')
+       | list
+       | length != 1
+  vars:
+    bastion_sshd_expected:
+      - "port {{ bastion_ssh_port }}"
+      - pubkeyauthentication yes
+      - passwordauthentication no
+      - kbdinteractiveauthentication no
+      - permitemptypasswords no
+      - permitrootlogin no
+      - allowtcpforwarding yes
+      - allowagentforwarding no
+      - gatewayports no
+      - x11forwarding no
+      - permittunnel no
+
+- name: Restart SSH if needed
+  ansible.builtin.meta: flush_handlers

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/templates/00-oilscope-bastion.conf.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/templates/00-oilscope-bastion.conf.j2
@@ -1,0 +1,12 @@
+# Managed by oilscope.platform.bastion.
+Port {{ bastion_ssh_port }}
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin no
+AllowTcpForwarding yes
+AllowAgentForwarding no
+GatewayPorts no
+X11Forwarding no
+PermitTunnel no

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tests/inventory
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tests/inventory
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+[bastion_test]

--- a/infrastructure/ansible/oilscope/platform/roles/bastion/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/bastion/tests/test.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Test the bastion role
+  hosts: bastion_test
+  become: true
+  roles:
+    - role: oilscope.platform.bastion
+      vars:
+        bastion_ssh_port: >-
+          {{ (lookup('ansible.builtin.file', playbook_dir
+             ~ '/../../../../../../../project-config.example.json') | from_json)
+             .vms.bastion.ssh_port | int }}

--- a/infrastructure/ssh/config.example
+++ b/infrastructure/ssh/config.example
@@ -4,7 +4,7 @@
 Host oilscope-bastion
     HostName <BASTION_PUBLIC_IP>
     User <YOUR_LINUX_USERNAME>
-    Port 8787
+    Port <BASTION_SSH_PORT_FROM_PROJECT_CONFIG>
     IdentityFile <YOUR_PRIVATE_KEY_PATH>
     IdentitiesOnly yes
     ForwardAgent no

--- a/infrastructure/terraform/modules/network/README.md
+++ b/infrastructure/terraform/modules/network/README.md
@@ -67,8 +67,8 @@ module "network" {
   workload_subnet_cidr   = local.config.network.workload_subnet_cidr
   ui_public_ports        = ["80", "443"]
 
-  bastion_ssh_port      = local.config.bastion.ssh_port
-  bastion_allowed_cidrs = local.config.bastion.allowed_cidrs
+  bastion_ssh_port      = local.bastion_vm.ssh_port
+  bastion_allowed_cidrs = local.bastion_vm.allowed_cidrs
 
   history_api_port = local.config.service_ports.history_api
   postgresql_port  = local.config.service_ports.postgresql

--- a/project-config.example.json
+++ b/project-config.example.json
@@ -37,7 +37,7 @@
       "assign_public_ip": true,
       "network_tags": ["bastion"],
       "secret_mappings": {},
-      "ssh_port": 2222,
+      "ssh_port": 8787,
       "allowed_cidrs": ["192.0.2.10/32"]
     },
     "infra": {


### PR DESCRIPTION
Adds the initial Ansible bootstrap flow for a fresh GCP bastion.
- Connects through the initial SSH port 22.
- Applies the bastion role.
- Switches Ansible to the configured SSH port.
- Verifies bastion and workload connectivity.
- Documents the bootstrap access flow.
Closes #133.