### PR TITLE
Create role-specific Compose files for workload VMs

### DIFF
--- a/infrastructure/ansible/oilscope/platform/playbooks/database.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/database.yml
@@ -18,7 +18,6 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
-        resolve_secrets_workload: "{{ oilscope_role }}"
 
     - role: oilscope.platform.database
       vars:
@@ -28,6 +27,4 @@
             ~ '/database:'
             ~ compose_project_config.registry.image_sha
           }}
-        database_application_image_tag: >-
-          {{ compose_project_config.registry.image_sha }}
         database_postgres_password: "{{ resolve_secrets_result.POSTGRES_PASSWORD }}"

--- a/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
@@ -17,18 +17,9 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
-        resolve_secrets_workload: "{{ oilscope_role }}"
 
     - role: oilscope.platform.fetcher
       vars:
-        fetcher_compose_environment:
-          APP_IMAGE_TAG: "{{ compose_project_config.registry.image_sha }}"
-          POSTGRES_IMAGE: >-
-            {{
-              compose_project_config.registry.repository
-              ~ '/database:'
-              ~ compose_project_config.registry.image_sha
-            }}
         fetcher_database_host: >-
           {{ hostvars[groups['database'][0]].internal_ip }}
         fetcher_postgres_password: "{{ resolve_secrets_result.POSTGRES_PASSWORD }}"

--- a/infrastructure/ansible/oilscope/platform/playbooks/history.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/history.yml
@@ -18,16 +18,7 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
-        resolve_secrets_workload: "{{ oilscope_role }}"
 
     - role: oilscope.platform.history
       vars:
-        history_application_image_tag: >-
-          {{ compose_project_config.registry.image_sha }}
-        history_postgres_image: >-
-          {{
-            compose_project_config.registry.repository
-            ~ '/database:'
-            ~ compose_project_config.registry.image_sha
-          }}
         history_postgres_password: "{{ resolve_secrets_result.POSTGRES_PASSWORD }}"

--- a/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
@@ -17,16 +17,7 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
-        resolve_secrets_workload: "{{ oilscope_role }}"
 
     - role: oilscope.platform.ui
       vars:
-        ui_application_image_tag: >-
-          {{ compose_project_config.registry.image_sha }}
-        ui_postgres_image: >-
-          {{
-            compose_project_config.registry.repository
-            ~ '/database:'
-            ~ compose_project_config.registry.image_sha
-          }}
         ui_postgres_password: "{{ resolve_secrets_result.POSTGRES_PASSWORD }}"

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/README.md
@@ -1,7 +1,12 @@
 # Compose project
 
-Installs the supported OilScope Compose definition and its non-secret deployment
-configuration.
+Installs the Compose definition for one OilScope workload VM. Each target gets
+only the services assigned to its role:
+
+- `database`: PostgreSQL and the one-shot migration service;
+- `history`: History only;
+- `fetcher`: Fetcher only;
+- `ui`: UI only.
 
 ## Requirements
 
@@ -12,14 +17,15 @@ The controller must have access to the external project configuration JSON.
 
 - `compose_project_config_path`: required controller-side path to the non-secret
   project configuration JSON.
-- `compose_project_workload`: required key in the JSON `workloads` object.
+- `compose_project_workload`: required host role: `database`, `history`,
+  `fetcher`, or `ui`.
 - `compose_project_dir`: installation directory; defaults to `/opt/oilscope/app`.
 - `compose_project_owner` and `compose_project_group`: installed file ownership;
   both default to `deploy`.
 
-The selected workload's `image_tag` must be a full 40-character Git SHA. The
-role writes it as `APP_IMAGE_TAG` in `deployment.env`. Secret values are not
-handled by this role.
+Image references are rendered from `registry.repository` and
+`registry.image_sha` in the project configuration. Secret values and private
+registry authentication are not handled by this role.
 
 ## Example playbook
 
@@ -32,11 +38,24 @@ handled by this role.
     - role: oilscope.platform.compose_project
       vars:
         compose_project_config_path: /srv/oilscope/project-config.json
-        compose_project_workload: history
+        compose_project_workload: "{{ oilscope_role }}"
 ```
 
-The installed files are `/opt/oilscope/app/compose.yaml` and
-`/opt/oilscope/app/deployment.env` by default.
+The installed file is `/opt/oilscope/app/compose.yaml`.
+
+`compose.deployment.yaml.j2` remains temporarily as input to the legacy
+Terraform cloud-init path. The Ansible role does not install it.
+
+## Test
+
+From the collection directory, render and validate all four definitions with:
+
+```sh
+ansible-playbook \
+  -i roles/compose_project/tests/inventory \
+  roles/compose_project/tests/test.yml \
+  -e project_config_path=/absolute/path/to/project-config.json
+```
 
 ## License
 

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/tasks/main.yml
@@ -5,12 +5,6 @@
     file: "{{ compose_project_config_path }}"
     name: compose_project_config
 
-- name: Select image SHA from project configuration
-  ansible.builtin.set_fact:
-    compose_project_image_sha: >-
-      {{ compose_project_config.registry.image_sha
-         | default('') }}
-
 - name: Create application directory
   ansible.builtin.file:
     path: "{{ compose_project_dir }}"
@@ -21,16 +15,13 @@
 
 - name: Install Compose definition
   ansible.builtin.template:
-    src: compose.deployment.yaml.j2
+    src: "{{ compose_project_templates[compose_project_workload] }}"
     dest: "{{ compose_project_dir }}/compose.yaml"
     owner: "{{ compose_project_owner }}"
     group: "{{ compose_project_group }}"
     mode: "0644"
 
-- name: Install non-secret deployment configuration
-  ansible.builtin.template:
-    src: deployment-config.j2
-    dest: "{{ compose_project_dir }}/deployment.env"
-    owner: "{{ compose_project_owner }}"
-    group: "{{ compose_project_group }}"
-    mode: "0640"
+- name: Remove the obsolete shared deployment configuration
+  ansible.builtin.file:
+    path: "{{ compose_project_dir }}/deployment.env"
+    state: absent

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.database.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.database.yaml.j2
@@ -1,0 +1,55 @@
+name: petroscope
+
+services:
+  postgres:
+    image: "{{ compose_project_config.registry.repository }}/database:{{ compose_project_config.registry.image_sha }}"
+    platform: ${POSTGRES_PLATFORM:-linux/amd64}
+    pull_policy: ${POSTGRES_PULL_POLICY:-always}
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-oil_tracker}
+      POSTGRES_USER: ${POSTGRES_USER:-oil_tracker}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
+      PGDATA: /var/lib/postgresql/18/docker
+      TZ: UTC
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_cron
+      - -c
+      - cron.database_name=${POSTGRES_DB:-oil_tracker}
+      - -c
+      - cron.use_background_workers=on
+    ports:
+      - "${DATABASE_BIND_ADDRESS:-0.0.0.0}:${DATABASE_HOST_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    stop_grace_period: 30s
+
+  migrate:
+    image: "{{ compose_project_config.registry.repository }}/database:{{ compose_project_config.registry.image_sha }}"
+    platform: ${POSTGRES_PLATFORM:-linux/amd64}
+    pull_policy: ${POSTGRES_PULL_POLICY:-always}
+    restart: "no"
+    command: ["petroscope-migrate"]
+    environment:
+      PGHOST: postgres
+      PGPORT: 5432
+      PGUSER: ${POSTGRES_USER:-oil_tracker}
+      PGDATABASE: ${POSTGRES_DB:-oil_tracker}
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.fetcher.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.fetcher.yaml.j2
@@ -1,0 +1,33 @@
+name: petroscope
+
+services:
+  fetcher:
+    image: "{{ compose_project_config.registry.repository }}/fetcher:{{ compose_project_config.registry.image_sha }}"
+    platform: ${APPLICATION_PLATFORM:-linux/amd64}
+    pull_policy: ${APPLICATION_PULL_POLICY:-always}
+    restart: unless-stopped
+    init: true
+    environment:
+      OILPRICEAPI_KEY: ${OILPRICEAPI_KEY:?OILPRICEAPI_KEY is required}
+      DATA_PROVIDER: ${DATA_PROVIDER:-oilpriceapi}
+      # yamllint disable rule:line-length
+      DATABASE_URL: postgres://${POSTGRES_USER:-oil_tracker}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${DATABASE_HOST:?DATABASE_HOST is required}:${DATABASE_PORT:-5432}/${POSTGRES_DB:-oil_tracker}?sslmode=${DATABASE_SSLMODE:-disable}
+      # yamllint enable rule:line-length
+      PGMQ_QUEUE: ${PGMQ_QUEUE:-price_observations}
+      FETCH_CRON_HOURS: ${FETCH_CRON_HOURS:-0,6,12,18}
+      FETCH_TIMEZONE: ${FETCH_TIMEZONE:-UTC}
+      FETCH_ON_STARTUP: ${FETCH_ON_STARTUP:-true}
+      REQUEST_TIMEOUT_SECONDS: ${REQUEST_TIMEOUT_SECONDS:-15}
+      LISTEN_ADDRESS: ${FETCHER_LISTEN_ADDRESS:-0.0.0.0:8002}
+      TZ: UTC
+    ports:
+      - "${FETCHER_BIND_ADDRESS:-0.0.0.0}:${FETCHER_HOST_PORT:-8002}:8002"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8002/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    stop_grace_period: 20s
+    security_opt:
+      - no-new-privileges:true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.history.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.history.yaml.j2
@@ -1,0 +1,40 @@
+name: petroscope
+
+services:
+  history:
+    image: "{{ compose_project_config.registry.repository }}/history:{{ compose_project_config.registry.image_sha }}"
+    platform: ${APPLICATION_PLATFORM:-linux/amd64}
+    pull_policy: ${APPLICATION_PULL_POLICY:-always}
+    restart: unless-stopped
+    init: true
+    environment:
+      # yamllint disable rule:line-length
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-oil_tracker}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${DATABASE_HOST:?DATABASE_HOST is required}:${DATABASE_PORT:-5432}/${POSTGRES_DB:-oil_tracker}?sslmode=${DATABASE_SSLMODE:-disable}
+      # yamllint enable rule:line-length
+      PGMQ_QUEUE: ${PGMQ_QUEUE:-price_observations}
+      PGMQ_VISIBILITY_TIMEOUT_SECONDS: ${PGMQ_VISIBILITY_TIMEOUT_SECONDS:-60}
+      PGMQ_POLL_INTERVAL_SECONDS: ${PGMQ_POLL_INTERVAL_SECONDS:-1}
+      PGMQ_MAX_ATTEMPTS: ${PGMQ_MAX_ATTEMPTS:-5}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      TZ: UTC
+    ports:
+      - "${HISTORY_BIND_ADDRESS:-0.0.0.0}:${HISTORY_HOST_PORT:-8001}:8001"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import json, urllib.request;
+          data = json.load(urllib.request.urlopen("http://127.0.0.1:8001/health", timeout=3));
+          assert data["status"] == "ok";
+          assert data["database"] == "connected";
+          assert data["pgmq_extension"] == "installed";
+          assert data["pgmq_consumer"] == "ready"
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+    stop_grace_period: 20s
+    security_opt:
+      - no-new-privileges:true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.ui.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.ui.yaml.j2
@@ -1,0 +1,33 @@
+name: petroscope
+
+services:
+  ui:
+    image: "{{ compose_project_config.registry.repository }}/ui:{{ compose_project_config.registry.image_sha }}"
+    platform: ${APPLICATION_PLATFORM:-linux/amd64}
+    pull_policy: ${APPLICATION_PULL_POLICY:-always}
+    restart: unless-stopped
+    init: true
+    environment:
+      HISTORY_SERVICE_URL: ${HISTORY_SERVICE_URL:?HISTORY_SERVICE_URL is required}
+      # yamllint disable rule:line-length
+      DATABASE_URL: postgresql://${POSTGRES_USER:-oil_tracker}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${DATABASE_HOST:?DATABASE_HOST is required}:${DATABASE_PORT:-5432}/${POSTGRES_DB:-oil_tracker}?sslmode=${DATABASE_SSLMODE:-disable}
+      # yamllint enable rule:line-length
+      SESSION_TTL_SECONDS: ${SESSION_TTL_SECONDS:-2592000}
+      SESSION_COOKIE_SECURE: ${SESSION_COOKIE_SECURE:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      TZ: UTC
+    ports:
+      - "${UI_BIND_ADDRESS:-0.0.0.0}:${UI_HTTP_PORT:-80}:8080"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3)"
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+    stop_grace_period: 20s
+    security_opt:
+      - no-new-privileges:true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/deployment-config.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/deployment-config.j2
@@ -1,1 +1,0 @@
-APP_IMAGE_TAG={{ compose_project_image_sha }}

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/tests/project-config.json.example
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/tests/project-config.json.example
@@ -1,7 +1,0 @@
-{
-  "workloads": {
-    "history": {
-      "image_tag": "f4bd2d001dd4ad7abcf04af967dca8e8a0f6d891"
-    }
-  }
-}

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/tests/test.yml
@@ -4,12 +4,41 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  roles:
-    - role: oilscope.platform.compose_project
+  tasks:
+    - name: Render the Compose definition for each workload role
+      ansible.builtin.include_role:
+        name: oilscope.platform.compose_project
       vars:
-        compose_project_dir: /tmp/oilscope-compose-project-test
+        compose_project_dir: >-
+          /tmp/oilscope-compose-project-test/{{ compose_project_workload }}
         compose_project_owner: "{{ lookup('ansible.builtin.env', 'USER') }}"
         compose_project_group: "{{ lookup('ansible.builtin.pipe', 'id -gn') }}"
-        compose_project_config_path: >-
-          {{ playbook_dir }}/project-config.json.example
-        compose_project_workload: history
+        compose_project_config_path: "{{ project_config_path }}"
+      loop:
+        - database
+        - history
+        - fetcher
+        - ui
+      loop_control:
+        loop_var: compose_project_workload
+
+    - name: Validate each rendered Compose definition
+      ansible.builtin.command:
+        argv:
+          - docker
+          - compose
+          - --file
+          - /tmp/oilscope-compose-project-test/{{ item }}/compose.yaml
+          - config
+          - --quiet
+      environment:
+        DATABASE_HOST: 127.0.0.1
+        HISTORY_SERVICE_URL: http://127.0.0.1:8001
+        OILPRICEAPI_KEY: test-only
+        POSTGRES_PASSWORD: test-only
+      changed_when: false
+      loop:
+        - database
+        - history
+        - fetcher
+        - ui

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/vars/main.yml
@@ -1,3 +1,7 @@
 # SPDX-License-Identifier: MIT-0
 ---
-# vars file for roles/compose_project
+compose_project_templates:
+  database: compose.database.yaml.j2
+  history: compose.history.yaml.j2
+  fetcher: compose.fetcher.yaml.j2
+  ui: compose.ui.yaml.j2

--- a/infrastructure/ansible/oilscope/platform/roles/database/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/database/README.md
@@ -15,10 +15,7 @@ The database image must contain `petroscope-migrate` and the migrations under
 ## Required variables
 
 - `database_postgres_image`: complete image reference pinned with
-  `@sha256:<64 hexadecimal characters>`.
-- `database_application_image_tag`: full 40-character Git SHA required while
-  rendering the shared Compose definition. Application services are not
-  started by this role.
+  a full 40-character Git SHA tag.
 - `database_postgres_password`: password supplied by the deployment secret
   mechanism. The role marks tasks receiving it with `no_log` and does not write
   it to disk.
@@ -48,8 +45,7 @@ The database image must contain `petroscope-migrate` and the migrations under
     - role: oilscope.platform.database
       vars:
         database_postgres_image: >-
-          ghcr.io/ua-academy-projects/push-and-pray/database@sha256:...
-        database_application_image_tag: 0123456789abcdef0123456789abcdef01234567
+          ghcr.io/ua-academy-projects/push-and-pray/database:0123456789abcdef0123456789abcdef01234567
         database_postgres_password: "{{ vault_database_password }}"
 ```
 

--- a/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
@@ -6,7 +6,6 @@ database_compose_project_name: petroscope
 database_postgres_service: postgres
 database_migration_service: migrate
 database_postgres_image: ""
-database_application_image_tag: ""
 database_postgres_password: ""
 database_postgres_user: oil_tracker
 database_postgres_name: oil_tracker

--- a/infrastructure/ansible/oilscope/platform/roles/database/tests/test.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/tests/test.yml
@@ -9,7 +9,6 @@
         name: database
       vars:
         database_postgres_image: postgres:18
-        database_application_image_tag: 0123456789abcdef0123456789abcdef01234567
         database_postgres_password: test-only
       register: database_invalid_image
       ignore_errors: true

--- a/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
@@ -4,8 +4,6 @@ database_runtime_environment: >-
   {{
     database_compose_environment
     | combine({
-      'POSTGRES_IMAGE': database_postgres_image,
-      'APP_IMAGE_TAG': database_application_image_tag,
       'POSTGRES_PASSWORD': database_postgres_password,
       'POSTGRES_USER': database_postgres_user,
       'POSTGRES_DB': database_postgres_name,

--- a/infrastructure/ansible/oilscope/platform/roles/history/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/history/README.md
@@ -16,9 +16,6 @@ secret values.
 
 ## Variables
 
-- `history_application_image_tag`: History image Git SHA.
-- `history_postgres_image`: PostgreSQL image required to parse the shared
-  Compose file.
 - `history_postgres_password`: password injected by the deployment workflow.
 
 ## Example
@@ -30,8 +27,6 @@ secret values.
   roles:
     - role: oilscope.platform.history
       vars:
-        history_application_image_tag: "0123456789abcdef0123456789abcdef01234567"
-        history_postgres_image: "ghcr.io/example/database@sha256:..."
         history_postgres_password: "{{ resolved_secrets.POSTGRES_PASSWORD }}"
 ```
 

--- a/infrastructure/ansible/oilscope/platform/roles/history/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/history/defaults/main.yml
@@ -4,8 +4,6 @@ history_compose_project_dir: /opt/oilscope/app
 history_compose_file: "{{ history_compose_project_dir }}/compose.yaml"
 history_compose_project_name: petroscope
 
-history_application_image_tag: ""
-history_postgres_image: ""
 history_postgres_password: ""
 history_health_retries: 30
 history_health_delay: 2

--- a/infrastructure/ansible/oilscope/platform/roles/history/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/history/tasks/main.yml
@@ -2,8 +2,6 @@
 ---
 - name: Deploy only History
   environment:
-    APP_IMAGE_TAG: "{{ history_application_image_tag }}"
-    POSTGRES_IMAGE: "{{ history_postgres_image }}"
     POSTGRES_PASSWORD: "{{ history_postgres_password }}"
     DATABASE_HOST: "{{ hostvars[groups['database'][0]].internal_ip }}"
   no_log: true

--- a/infrastructure/ansible/oilscope/platform/roles/ui/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/README.md
@@ -16,9 +16,6 @@ The deployment workflow retrieves `POSTGRES_PASSWORD` and passes it as
 
 ## Variables
 
-- `ui_application_image_tag`: UI image Git SHA.
-- `ui_postgres_image`: PostgreSQL image required to parse the shared Compose
-  file.
 - `ui_postgres_password`: password injected by the deployment workflow.
 - `ui_health_retries` and `ui_health_delay`: Docker health-check polling
   controls, defaulting to 30 attempts every 2 seconds.
@@ -32,8 +29,6 @@ The deployment workflow retrieves `POSTGRES_PASSWORD` and passes it as
   roles:
     - role: oilscope.platform.ui
       vars:
-        ui_application_image_tag: "0123456789abcdef0123456789abcdef01234567"
-        ui_postgres_image: "ghcr.io/example/database@sha256:..."
         ui_postgres_password: "{{ resolved_secrets.POSTGRES_PASSWORD }}"
 ```
 

--- a/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
@@ -4,8 +4,6 @@ ui_compose_project_dir: /opt/oilscope/app
 ui_compose_file: "{{ ui_compose_project_dir }}/compose.yaml"
 ui_compose_project_name: petroscope
 
-ui_application_image_tag: ""
-ui_postgres_image: ""
 ui_postgres_password: ""
 ui_health_retries: 30
 ui_health_delay: 2

--- a/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
@@ -2,8 +2,6 @@
 ---
 - name: Deploy only UI
   environment:
-    APP_IMAGE_TAG: "{{ ui_application_image_tag }}"
-    POSTGRES_IMAGE: "{{ ui_postgres_image }}"
     POSTGRES_PASSWORD: "{{ ui_postgres_password }}"
     DATABASE_HOST: "{{ hostvars[groups['database'][0]].internal_ip }}"
     HISTORY_SERVICE_URL: >-


### PR DESCRIPTION
- Added separate templates for Database, History, Fetcher, and UI.
- Database Compose contains only PostgreSQL and migrations; every other Compose file contains only its own service.
- Removed cross-VM depends_on relationships and unrelated variables.
- Updated compose_project to install the correct template as /opt/oilscope/app/compose.yaml based on the host role.