### PR TITLE
Correct the Docker Engine pin for Ubuntu 26.04 VMs

### DIFF
--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
@@ -20,9 +20,8 @@ though the deployment playbook applies the baseline first regardless.
 ## Role variables
 
 - `docker_engine_version`: exact apt version for the pinned packages; defaults
-  to `5:29.7.2-1~ubuntu.26.04~resolute`. The suffix ties the value to one
-  Ubuntu release, so re-verify with `apt-cache madison docker-ce` on the target
-  release before bumping.
+  to `5:29.7.2-1~ubuntu.26.04~resolute`. Re-verify with
+  `apt-cache madison docker-ce` before bumping.
 - `docker_engine_pinned_packages`: packages installed at that exact version;
   defaults to `docker-ce` and `docker-ce-cli`.
 - `docker_engine_packages`: packages installed unversioned; defaults to
@@ -32,10 +31,8 @@ though the deployment playbook applies the baseline first regardless.
   `docker-compose-v2`, `containerd` and `runc`.
 - `docker_engine_hold` and `docker_engine_held_packages`: whether to mark
   packages `hold`, and which ones. Enabled by default.
-- `docker_engine_validate_release` and `docker_engine_release`: whether to
-  refuse to run when the pinned version was built for a different Ubuntu
-  release, and the codename the suffix encodes. Enabled by default, and set to
-  `resolute` to match the version above.
+- `docker_engine_validate_release`: refuse to run when the pinned version was
+  built for a different Ubuntu release. Enabled by default.
 - `docker_engine_keyring_path`, `docker_engine_gpg_url`,
   `docker_engine_repository_url`, `docker_engine_repository_component`,
   `docker_engine_repository_path`: signing key and repository locations.

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/README.md
@@ -20,8 +20,9 @@ though the deployment playbook applies the baseline first regardless.
 ## Role variables
 
 - `docker_engine_version`: exact apt version for the pinned packages; defaults
-  to `5:29.7.2-1~ubuntu.22.04~jammy`. Re-verify with
-  `apt-cache madison docker-ce` before bumping.
+  to `5:29.7.2-1~ubuntu.26.04~resolute`. The suffix ties the value to one
+  Ubuntu release, so re-verify with `apt-cache madison docker-ce` on the target
+  release before bumping.
 - `docker_engine_pinned_packages`: packages installed at that exact version;
   defaults to `docker-ce` and `docker-ce-cli`.
 - `docker_engine_packages`: packages installed unversioned; defaults to
@@ -31,8 +32,10 @@ though the deployment playbook applies the baseline first regardless.
   `docker-compose-v2`, `containerd` and `runc`.
 - `docker_engine_hold` and `docker_engine_held_packages`: whether to mark
   packages `hold`, and which ones. Enabled by default.
-- `docker_engine_validate_release`: refuse to run when the pinned version was
-  built for a different Ubuntu release. Enabled by default.
+- `docker_engine_validate_release` and `docker_engine_release`: whether to
+  refuse to run when the pinned version was built for a different Ubuntu
+  release, and the codename the suffix encodes. Enabled by default, and set to
+  `resolute` to match the version above.
 - `docker_engine_keyring_path`, `docker_engine_gpg_url`,
   `docker_engine_repository_url`, `docker_engine_repository_component`,
   `docker_engine_repository_path`: signing key and repository locations.

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
@@ -28,6 +28,7 @@ docker_engine_held_packages:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - docker-buildx-plugin
   - docker-compose-plugin
 
 # Refuse to run when the pinned version was built for another Ubuntu release.

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
@@ -31,10 +31,7 @@ docker_engine_held_packages:
   - docker-compose-plugin
 
 # Refuse to run when the pinned version was built for another Ubuntu release.
-# docker_engine_release is the codename the suffix above encodes; the assert
-# in tasks/main.yml compares it with the codename the target actually reports.
 docker_engine_validate_release: true
-docker_engine_release: resolute
 
 # Repository and signing key.
 docker_engine_keyring_path: /etc/apt/keyrings/docker.asc

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/defaults/main.yml
@@ -3,7 +3,7 @@
 # Exact apt version of Docker Engine to install. The release suffix ties the
 # value to one Ubuntu release, so re-verify with `apt-cache madison docker-ce`
 # before bumping it. Docker package provisioning is owned by this Ansible role.
-docker_engine_version: "5:29.7.2-1~ubuntu.22.04~jammy"
+docker_engine_version: "5:29.7.2-1~ubuntu.26.04~resolute"
 
 # Packages installed at the pinned version above.
 docker_engine_pinned_packages:
@@ -31,7 +31,10 @@ docker_engine_held_packages:
   - docker-compose-plugin
 
 # Refuse to run when the pinned version was built for another Ubuntu release.
+# docker_engine_release is the codename the suffix above encodes; the assert
+# in tasks/main.yml compares it with the codename the target actually reports.
 docker_engine_validate_release: true
+docker_engine_release: resolute
 
 # Repository and signing key.
 docker_engine_keyring_path: /etc/apt/keyrings/docker.asc

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
@@ -1,22 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 ---
-- name: Refuse a pin that was built for another Ubuntu release
-  ansible.builtin.assert:
-    that:
-      - ansible_facts['distribution_release'] == docker_engine_release
-      - docker_engine_release in docker_engine_version
-    fail_msg: >-
-      docker_engine_version is {{ docker_engine_version }}, built for
-      {{ docker_engine_release }}, but this host reports
-      {{ ansible_facts['distribution_release'] }}. Re-verify the exact version
-      with `apt-cache madison docker-ce` on the target release and set both
-      docker_engine_version and docker_engine_release before running again.
-    success_msg: >-
-      The pinned Docker Engine version matches
-      {{ ansible_facts['distribution_release'] }}.
-    quiet: true
-  when: docker_engine_validate_release | bool
-
 - name: Create the apt keyring directory
   become: true
   ansible.builtin.file:

--- a/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/docker_engine/tasks/main.yml
@@ -1,5 +1,22 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 ---
+- name: Refuse a pin that was built for another Ubuntu release
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['distribution_release'] == docker_engine_release
+      - docker_engine_release in docker_engine_version
+    fail_msg: >-
+      docker_engine_version is {{ docker_engine_version }}, built for
+      {{ docker_engine_release }}, but this host reports
+      {{ ansible_facts['distribution_release'] }}. Re-verify the exact version
+      with `apt-cache madison docker-ce` on the target release and set both
+      docker_engine_version and docker_engine_release before running again.
+    success_msg: >-
+      The pinned Docker Engine version matches
+      {{ ansible_facts['distribution_release'] }}.
+    quiet: true
+  when: docker_engine_validate_release | bool
+
 - name: Create the apt keyring directory
   become: true
   ansible.builtin.file:

--- a/project-config.example.json
+++ b/project-config.example.json
@@ -28,7 +28,7 @@
     "bastion": {
       "role": "bastion",
       "machine_type": "e2-micro",
-      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
       "internal_ip": "10.0.0.2",
       "boot_disk": {
         "size_gb": 10,
@@ -43,7 +43,7 @@
     "infra": {
       "role": "database",
       "machine_type": "e2-micro",
-      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
       "internal_ip": "10.0.1.2",
       "boot_disk": {
         "size_gb": 10,
@@ -58,7 +58,7 @@
     "history": {
       "role": "history",
       "machine_type": "e2-small",
-      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
       "internal_ip": "10.0.1.3",
       "boot_disk": {
         "size_gb": 10,
@@ -73,7 +73,7 @@
     "fetcher": {
       "role": "fetcher",
       "machine_type": "e2-micro",
-      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
       "internal_ip": "10.0.1.4",
       "boot_disk": {
         "size_gb": 10,
@@ -89,7 +89,7 @@
     "ui": {
       "role": "ui",
       "machine_type": "e2-micro",
-      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
+      "image": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
       "internal_ip": "10.0.1.5",
       "boot_disk": {
         "size_gb": 10,


### PR DESCRIPTION
The docker_engine role installed docker-ce and docker-ce-cli at an exact apt version carrying the Ubuntu 22.04 suffix, 5:29.7.2-1~ubuntu.22.04~jammy. The role points apt at the Docker suite matching the host codename, and the Docker repository builds a separate package per Ubuntu release, so on an Ubuntu 26.04 target apt resolves against dists/resolute, where no jammy-suffixed version exists. The install failed and no VM reached the Compose step.

Pin the resolute build instead. The upstream version is unchanged - both docker-ce and docker-ce-cli 29.7.2 are published for resolute - so only the release suffix moves.

docker_engine_validate_release was declared in defaults and documented in the README as refusing to run when the pinned version was built for another Ubuntu release, but no task read it: the guard against exactly this failure existed only on paper. Record the codename the suffix encodes in a new docker_engine_release default and assert it against the codename the target reports, before any package is touched, so the next image change fails with a message naming both values rather than an apt resolution error midway through.

Documentation now quotes the same version string as the role default.

The legacy cloud-init implementation and pr-validation.yml are untouched.

Refs #153