### PR TITLE
Authenticate workload deployments to private GHCR

### DIFF
--- a/infrastructure/ansible/oilscope/platform/playbooks/database.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/database.yml
@@ -4,6 +4,7 @@
   hosts: database
   become: true
   gather_facts: true
+  force_handlers: true
 
   roles:
     - role: oilscope.platform.host_baseline
@@ -18,6 +19,16 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
+
+    - role: oilscope.platform.registry_auth
+      vars:
+        registry_auth_registry: >-
+          {{ compose_project_config.registry.repository
+             | regex_replace('/.*$', '') }}
+        registry_auth_username: >-
+          {{ compose_project_config.registry.username | default('') }}
+        registry_auth_token: >-
+          {{ resolve_secrets_result.GHCR_TOKEN | default('') }}
 
     - role: oilscope.platform.database
       vars:

--- a/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
@@ -4,6 +4,7 @@
   hosts: fetcher
   become: true
   gather_facts: true
+  force_handlers: true
   roles:
     - role: oilscope.platform.host_baseline
 
@@ -17,6 +18,16 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
+
+    - role: oilscope.platform.registry_auth
+      vars:
+        registry_auth_registry: >-
+          {{ compose_project_config.registry.repository
+             | regex_replace('/.*$', '') }}
+        registry_auth_username: >-
+          {{ compose_project_config.registry.username | default('') }}
+        registry_auth_token: >-
+          {{ resolve_secrets_result.GHCR_TOKEN | default('') }}
 
     - role: oilscope.platform.fetcher
       vars:

--- a/infrastructure/ansible/oilscope/platform/playbooks/history.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/history.yml
@@ -4,6 +4,7 @@
   hosts: history
   become: true
   gather_facts: true
+  force_handlers: true
 
   roles:
     - role: oilscope.platform.host_baseline
@@ -18,6 +19,16 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
+
+    - role: oilscope.platform.registry_auth
+      vars:
+        registry_auth_registry: >-
+          {{ compose_project_config.registry.repository
+             | regex_replace('/.*$', '') }}
+        registry_auth_username: >-
+          {{ compose_project_config.registry.username | default('') }}
+        registry_auth_token: >-
+          {{ resolve_secrets_result.GHCR_TOKEN | default('') }}
 
     - role: oilscope.platform.history
       vars:

--- a/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
@@ -4,6 +4,7 @@
   hosts: ui
   become: true
   gather_facts: true
+  force_handlers: true
   roles:
     - role: oilscope.platform.host_baseline
 
@@ -17,6 +18,16 @@
     - role: oilscope.platform.resolve_secrets
       vars:
         resolve_secrets_config_path: "{{ project_config_path }}"
+
+    - role: oilscope.platform.registry_auth
+      vars:
+        registry_auth_registry: >-
+          {{ compose_project_config.registry.repository
+             | regex_replace('/.*$', '') }}
+        registry_auth_username: >-
+          {{ compose_project_config.registry.username | default('') }}
+        registry_auth_token: >-
+          {{ resolve_secrets_result.GHCR_TOKEN | default('') }}
 
     - role: oilscope.platform.ui
       vars:

--- a/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/defaults/main.yml
@@ -13,4 +13,5 @@ database_bind_address: 0.0.0.0
 database_host_port: 5432
 database_health_retries: 30
 database_health_delay: 2
+database_docker_config_dir: /run/oilscope/docker-auth
 database_compose_environment: {}

--- a/infrastructure/ansible/oilscope/platform/roles/database/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/tasks/main.yml
@@ -12,6 +12,8 @@
       - image
       - pull
       - "{{ database_postgres_image }}"
+  environment:
+    DOCKER_CONFIG: "{{ database_docker_config_dir }}"
   register: database_image_pull
   changed_when: >-
     'Downloaded newer image' in database_image_pull.stdout or

--- a/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/database/vars/main.yml
@@ -4,6 +4,7 @@ database_runtime_environment: >-
   {{
     database_compose_environment
     | combine({
+      'DOCKER_CONFIG': database_docker_config_dir,
       'POSTGRES_PASSWORD': database_postgres_password,
       'POSTGRES_USER': database_postgres_user,
       'POSTGRES_DB': database_postgres_name,

--- a/infrastructure/ansible/oilscope/platform/roles/fetcher/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/fetcher/defaults/main.yml
@@ -13,4 +13,5 @@ fetcher_bind_address: 0.0.0.0
 fetcher_host_port: 8002
 fetcher_health_retries: 30
 fetcher_health_delay: 2
+fetcher_docker_config_dir: /run/oilscope/docker-auth
 fetcher_compose_environment: {}

--- a/infrastructure/ansible/oilscope/platform/roles/fetcher/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/fetcher/vars/main.yml
@@ -4,6 +4,7 @@ fetcher_runtime_environment: >-
   {{
     fetcher_compose_environment
     | combine({
+      'DOCKER_CONFIG': fetcher_docker_config_dir,
       'POSTGRES_PASSWORD': fetcher_postgres_password,
       'POSTGRES_USER': fetcher_postgres_user,
       'POSTGRES_DB': fetcher_postgres_name,

--- a/infrastructure/ansible/oilscope/platform/roles/history/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/history/defaults/main.yml
@@ -7,3 +7,4 @@ history_compose_project_name: petroscope
 history_postgres_password: ""
 history_health_retries: 30
 history_health_delay: 2
+history_docker_config_dir: /run/oilscope/docker-auth

--- a/infrastructure/ansible/oilscope/platform/roles/history/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/history/tasks/main.yml
@@ -2,6 +2,7 @@
 ---
 - name: Deploy only History
   environment:
+    DOCKER_CONFIG: "{{ history_docker_config_dir }}"
     POSTGRES_PASSWORD: "{{ history_postgres_password }}"
     DATABASE_HOST: "{{ hostvars[groups['database'][0]].internal_ip }}"
   no_log: true

--- a/infrastructure/ansible/oilscope/platform/roles/registry_auth/README.md
+++ b/infrastructure/ansible/oilscope/platform/roles/registry_auth/README.md
@@ -1,0 +1,34 @@
+# Registry authentication role
+
+Authenticates a workload VM to a private container registry for the duration
+of one deployment play. The role receives the token in memory from
+`resolve_secrets`, passes it to `docker login` through standard input, and
+stores Docker's generated configuration only under `/run`.
+
+## Variables
+
+- `registry_auth_registry`: registry hostname; defaults to `ghcr.io`.
+- `registry_auth_username`: non-secret GitHub username that owns the token.
+- `registry_auth_token`: in-memory token returned by `resolve_secrets`.
+- `registry_auth_docker_config_dir`: transient Docker configuration directory;
+  defaults to `/run/oilscope/docker-auth`.
+
+## Security behavior
+
+- Token-bearing tasks use `no_log: true`.
+- The token is sent to `docker login` with `--password-stdin`.
+- The transient directory is owned by root with mode `0700`.
+- A failed login removes the directory immediately.
+- A successful login notifies a cleanup handler. Deployment plays using this
+  role set `force_handlers: true`, so a later workload failure still removes
+  the credentials.
+- No registry token is written to project configuration, Ansible defaults,
+  Compose templates, or Terraform state.
+
+The workload role that follows this role must pass
+`registry_auth_docker_config_dir` as `DOCKER_CONFIG` to every command that may
+pull an image.
+
+## License
+
+GPL-2.0-or-later

--- a/infrastructure/ansible/oilscope/platform/roles/registry_auth/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/registry_auth/defaults/main.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+registry_auth_registry: ghcr.io
+registry_auth_username: ""
+registry_auth_token: ""
+registry_auth_docker_config_dir: /run/oilscope/docker-auth

--- a/infrastructure/ansible/oilscope/platform/roles/registry_auth/handlers/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/registry_auth/handlers/main.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Remove transient Docker registry credentials
+  become: true
+  ansible.builtin.file:
+    path: "{{ registry_auth_docker_config_dir }}"
+    state: absent

--- a/infrastructure/ansible/oilscope/platform/roles/registry_auth/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/registry_auth/meta/main.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Authenticate workload deployments to a private container registry
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+  galaxy_tags:
+    - containers
+    - docker
+    - security
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/registry_auth/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/registry_auth/tasks/main.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Remove stale transient Docker registry credentials
+  become: true
+  ansible.builtin.file:
+    path: "{{ registry_auth_docker_config_dir }}"
+    state: absent
+
+- name: Record whether a registry token is available
+  ansible.builtin.set_fact:
+    registry_auth_token_available: "{{ registry_auth_token | length > 0 }}"
+  no_log: true
+
+- name: Require a registry username
+  ansible.builtin.fail:
+    msg: registry_auth_username must contain the GitHub account that owns the token.
+  when: registry_auth_username | trim | length == 0
+
+- name: Require a registry token
+  ansible.builtin.fail:
+    msg: GHCR_TOKEN is missing or empty for this workload.
+  when: not registry_auth_token_available
+
+- name: Create the transient Docker configuration directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ registry_auth_docker_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Authenticate to the private container registry
+  block:
+    - name: Log in using the token resolved from Secret Manager
+      become: true
+      ansible.builtin.command:
+        argv:
+          - docker
+          - login
+          - "{{ registry_auth_registry }}"
+          - --username
+          - "{{ registry_auth_username }}"
+          - --password-stdin
+        stdin: "{{ registry_auth_token }}"
+        stdin_add_newline: false
+      environment:
+        DOCKER_CONFIG: "{{ registry_auth_docker_config_dir }}"
+      changed_when: true
+      no_log: true
+      notify: Remove transient Docker registry credentials
+
+  rescue:
+    - name: Remove credentials after a failed registry login
+      become: true
+      ansible.builtin.file:
+        path: "{{ registry_auth_docker_config_dir }}"
+        state: absent
+
+    - name: Report the registry authentication failure
+      ansible.builtin.fail:
+        msg: Authentication to the private container registry failed.

--- a/infrastructure/ansible/oilscope/platform/roles/secret_versions/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/secret_versions/tasks/main.yml
@@ -109,6 +109,13 @@
   loop_control:
     label: "{{ item.variable }}"
 
+- name: Refuse to upload incomplete secret versions
+  ansible.builtin.fail:
+    msg: >-
+      Required secret source variables are missing or empty:
+      {{ secret_versions_absent | join(', ') }}
+  when: secret_versions_absent | default([]) | length > 0
+
 - name: Look for the containers
   ansible.builtin.command:
     argv:

--- a/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/defaults/main.yml
@@ -7,3 +7,4 @@ ui_compose_project_name: petroscope
 ui_postgres_password: ""
 ui_health_retries: 30
 ui_health_delay: 2
+ui_docker_config_dir: /run/oilscope/docker-auth

--- a/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/ui/tasks/main.yml
@@ -2,6 +2,7 @@
 ---
 - name: Deploy only UI
   environment:
+    DOCKER_CONFIG: "{{ ui_docker_config_dir }}"
     POSTGRES_PASSWORD: "{{ ui_postgres_password }}"
     DATABASE_HOST: "{{ hostvars[groups['database'][0]].internal_ip }}"
     HISTORY_SERVICE_URL: >-

--- a/infrastructure/terraform/project-config.schema.json
+++ b/infrastructure/terraform/project-config.schema.json
@@ -47,11 +47,15 @@
     "registry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repository", "image_sha"],
+      "required": ["repository", "username", "image_sha"],
       "properties": {
         "repository": {
           "type": "string",
           "minLength": 1
+        },
+        "username": {
+          "type": "string",
+          "pattern": "^(?=.{1,39}$)[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
         },
         "image_sha": {
           "type": "string",

--- a/project-config.example.json
+++ b/project-config.example.json
@@ -13,6 +13,7 @@
   },
   "registry": {
     "repository": "ghcr.io/example-org/example-project",
+    "username": "example-operator",
     "image_sha": "0123456789abcdef0123456789abcdef01234567"
   },
   "network": {
@@ -52,7 +53,8 @@
       "assign_public_ip": false,
       "network_tags": ["infra"],
       "secret_mappings": {
-        "POSTGRES_PASSWORD": "example-db-password"
+        "POSTGRES_PASSWORD": "example-db-password",
+        "GHCR_TOKEN": "example-ghcr-token"
       }
     },
     "history": {
@@ -67,7 +69,8 @@
       "assign_public_ip": false,
       "network_tags": ["history"],
       "secret_mappings": {
-        "POSTGRES_PASSWORD": "example-db-password"
+        "POSTGRES_PASSWORD": "example-db-password",
+        "GHCR_TOKEN": "example-ghcr-token"
       }
     },
     "fetcher": {
@@ -83,7 +86,8 @@
       "network_tags": ["fetcher"],
       "secret_mappings": {
         "POSTGRES_PASSWORD": "example-db-password",
-        "OILPRICEAPI_KEY": "example-api-key"
+        "OILPRICEAPI_KEY": "example-api-key",
+        "GHCR_TOKEN": "example-ghcr-token"
       }
     },
     "ui": {
@@ -98,7 +102,8 @@
       "assign_public_ip": true,
       "network_tags": ["ui"],
       "secret_mappings": {
-        "POSTGRES_PASSWORD": "example-db-password"
+        "POSTGRES_PASSWORD": "example-db-password",
+        "GHCR_TOKEN": "example-ghcr-token"
       }
     }
   }


### PR DESCRIPTION
Adds secure GHCR authentication for Ansible workload deployments using a token resolved from Google Secret Manager.

## Changes
- Add the required non-secret `registry.username` field to the project configuration schema and example.
- Add `GHCR_TOKEN` Secret Manager mappings to Database, History, Fetcher, and UI.
- Keep the bastion without access to `GHCR_TOKEN`.
- Add the `oilscope.platform.registry_auth` role.
- Store Docker credentials temporarily under `/run/oilscope/docker-auth` with root ownership and `0700` permissions.
- Run registry authentication after `resolve_secrets` and before workload deployment.
- Pass the transient `DOCKER_CONFIG` to image pulls, Compose starts, and database migrations.
- Remove transient credentials after successful or failed deployments.
- Make `secret_versions` reject missing or empty secret sources before uploading any versions.