### PR TITLE
Add ordered Ansible workload deployment

### DIFF
--- a/infrastructure/ansible/oilscope/platform/README.md
+++ b/infrastructure/ansible/oilscope/platform/README.md
@@ -1,3 +1,22 @@
 # Ansible Collection - oilscope.platform
 
 Documentation for the collection.
+
+## Deploy all workloads
+
+Deploy the application workloads in dependency order:
+
+1. Database
+2. History
+3. Fetcher
+4. UI
+
+Run from the repository root:
+
+```bash
+ansible-playbook oilscope.platform.deploy_workloads \
+  -i infrastructure/ansible/inventory/oilscope.gcp.yml \
+  -e project_config_path=/absolute/path/project-config.json
+```
+
+The deployment stops if a workload fails, preventing dependent workloads from being deployed.

--- a/infrastructure/ansible/oilscope/platform/playbooks/database.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/database.yml
@@ -5,6 +5,7 @@
   become: true
   gather_facts: true
   force_handlers: true
+  any_errors_fatal: true
 
   roles:
     - role: oilscope.platform.host_baseline

--- a/infrastructure/ansible/oilscope/platform/playbooks/deploy_workloads.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/deploy_workloads.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Deploy Database workload
+  ansible.builtin.import_playbook: database.yml
+
+- name: Deploy History workload
+  ansible.builtin.import_playbook: history.yml
+
+- name: Deploy Fetcher workload
+  ansible.builtin.import_playbook: fetcher.yml
+
+- name: Deploy UI workload
+  ansible.builtin.import_playbook: ui.yml

--- a/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/fetcher.yml
@@ -5,6 +5,7 @@
   become: true
   gather_facts: true
   force_handlers: true
+  any_errors_fatal: true
   roles:
     - role: oilscope.platform.host_baseline
 

--- a/infrastructure/ansible/oilscope/platform/playbooks/history.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/history.yml
@@ -5,7 +5,7 @@
   become: true
   gather_facts: true
   force_handlers: true
-
+  any_errors_fatal: true
   roles:
     - role: oilscope.platform.host_baseline
 

--- a/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
@@ -5,6 +5,7 @@
   become: true
   gather_facts: true
   force_handlers: true
+  any_errors_fatal: true
   roles:
     - role: oilscope.platform.host_baseline
 


### PR DESCRIPTION
## Summary

- add `oilscope.platform.deploy_workloads`
- deploy workloads in dependency order: Database → History → Fetcher → UI
- stop dependent deployments when a workload fails
- document the full deployment command

Closes #154