### PR TITLE
159 add traefik https ingress with lets encrypt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{yml,yaml,j2}]
+indent_style = space
+indent_size = 2

--- a/infrastructure/ansible/oilscope/platform/README.md
+++ b/infrastructure/ansible/oilscope/platform/README.md
@@ -2,6 +2,16 @@
 
 Documentation for the collection.
 
+## Validate configuration
+
+Before deploying, validate your project configuration file against the schema:
+
+​```bash
+uvx check-jsonschema \
+  --schemafile infrastructure/terraform/project-config.schema.json \
+  /absolute/path/project-config.json
+​```
+
 ## Deploy all workloads
 
 Deploy the application workloads in dependency order:

--- a/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
+++ b/infrastructure/ansible/oilscope/platform/playbooks/ui.yml
@@ -30,6 +30,14 @@
         registry_auth_token: >-
           {{ resolve_secrets_result.GHCR_TOKEN | default('') }}
 
+    - role: oilscope.platform.compose_project
+      vars:
+        compose_project_config_path: "{{ project_config_path }}"
+        compose_project_dir: /opt/oilscope/proxy
+        compose_project_workload: proxy
+
+    - role: oilscope.platform.edge_proxy
+
     - role: oilscope.platform.ui
       vars:
         ui_postgres_password: "{{ resolve_secrets_result.POSTGRES_PASSWORD }}"

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.proxy.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.proxy.yaml.j2
@@ -1,0 +1,35 @@
+name: oilscope-proxy
+services:
+  traefik:
+    image: traefik:v3.7.12
+    restart: unless-stopped
+    init: true
+    command:
+      - "--entrypoints.websecure.address=:443"
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=false"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      >-
+      - --certificatesresolvers.letsencrypt.acme.email={{
+        compose_project_config.vms.ui.public_endpoint.acme_mail }} 
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--ping=true"
+      - "--log.level.INFO"
+    ports: - "443:443"
+    volumes:
+      - "{{ compose_project_dir }}/dynamic:/etc/traefik/dynamic:ro"
+      - "{{ compose_project_dir }}/acme.json:/letsencrypt/acme.json"
+    networks:
+      - oilscope-edge
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    stop_grace_period: 20s
+    security_opt:
+      - no-new-privileges:true
+networks:
+  oilscope-edge:
+    external: true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.proxy.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.proxy.yaml.j2
@@ -1,4 +1,5 @@
 name: oilscope-proxy
+
 services:
   traefik:
     image: traefik:v3.7.12
@@ -9,13 +10,14 @@ services:
       - "--providers.file.directory=/etc/traefik/dynamic"
       - "--providers.file.watch=false"
       - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
-      >-
-      - --certificatesresolvers.letsencrypt.acme.email={{
-        compose_project_config.vms.ui.public_endpoint.acme_mail }} 
+      - >-
+        --certificatesresolvers.letsencrypt.acme.email={{
+          compose_project_config.vms.ui.public_endpoint.acme_email }}
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
       - "--ping=true"
-      - "--log.level.INFO"
-    ports: - "443:443"
+      - "--log.level=INFO"
+    ports:
+      - "443:443"
     volumes:
       - "{{ compose_project_dir }}/dynamic:/etc/traefik/dynamic:ro"
       - "{{ compose_project_dir }}/acme.json:/letsencrypt/acme.json"
@@ -30,6 +32,7 @@ services:
     stop_grace_period: 20s
     security_opt:
       - no-new-privileges:true
+
 networks:
   oilscope-edge:
     external: true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.ui.yaml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/templates/compose.ui.yaml.j2
@@ -13,11 +13,9 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-oil_tracker}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${DATABASE_HOST:?DATABASE_HOST is required}:${DATABASE_PORT:-5432}/${POSTGRES_DB:-oil_tracker}?sslmode=${DATABASE_SSLMODE:-disable}
       # yamllint enable rule:line-length
       SESSION_TTL_SECONDS: ${SESSION_TTL_SECONDS:-2592000}
-      SESSION_COOKIE_SECURE: ${SESSION_COOKIE_SECURE:-false}
+      SESSION_COOKIE_SECURE: "true"
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       TZ: UTC
-    ports:
-      - "${UI_BIND_ADDRESS:-0.0.0.0}:${UI_HTTP_PORT:-80}:8080"
     healthcheck:
       test:
         - CMD
@@ -31,3 +29,8 @@ services:
     stop_grace_period: 20s
     security_opt:
       - no-new-privileges:true
+    networks:
+      - oilscope-edge
+networks:
+  oilscope-edge:
+    external: true

--- a/infrastructure/ansible/oilscope/platform/roles/compose_project/vars/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/compose_project/vars/main.yml
@@ -5,3 +5,4 @@ compose_project_templates:
   history: compose.history.yaml.j2
   fetcher: compose.fetcher.yaml.j2
   ui: compose.ui.yaml.j2
+  proxy: compose.proxy.yaml.j2

--- a/infrastructure/ansible/oilscope/platform/roles/edge_proxy/defaults/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/edge_proxy/defaults/main.yml
@@ -1,0 +1,4 @@
+edge_proxy_dir: /opt/oilscope/proxy
+edge_proxy_compose_file: "{{ edge_proxy_dir }}/compose.yaml"
+edge_proxy_compose_project_name: oilscope-proxy
+edge_proxy_network_name: oilscope-edge

--- a/infrastructure/ansible/oilscope/platform/roles/edge_proxy/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/edge_proxy/meta/main.yml
@@ -1,0 +1,9 @@
+
+---
+galaxy_info:
+  author: Push and Pray team
+  description: Install and run Traefik as the UI VM's edge HTTPS proxy
+  license: GPL-2.0-or-later
+  min_ansible_version: "2.16"
+
+dependencies: []

--- a/infrastructure/ansible/oilscope/platform/roles/edge_proxy/meta/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/edge_proxy/meta/main.yml
@@ -1,4 +1,3 @@
-
 ---
 galaxy_info:
   author: Push and Pray team

--- a/infrastructure/ansible/oilscope/platform/roles/edge_proxy/tasks/main.yml
+++ b/infrastructure/ansible/oilscope/platform/roles/edge_proxy/tasks/main.yml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+---
+- name: Check whether the shared edge network already exists
+  ansible.builtin.command:
+    argv: [docker, network, inspect, "{{ edge_proxy_network_name }}"]
+  register: edge_proxy_network_check
+  changed_when: false
+  failed_when: false
+
+- name: Create the shared edge network
+  ansible.builtin.command:
+    argv: [docker, network, create, "{{ edge_proxy_network_name }}"]
+  when: edge_proxy_network_check.rc != 0
+  changed_when: true
+
+- name: Create the dynamic configuration directory
+  ansible.builtin.file:
+    path: "{{ edge_proxy_dir }}/dynamic"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install the Traefik dynamic routing configuration
+  ansible.builtin.template:
+    src: dynamic.yml.j2
+    dest: "{{ edge_proxy_dir }}/dynamic/dynamic.yml"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Check whether acme.json already exists
+  ansible.builtin.stat:
+    path: "{{ edge_proxy_dir }}/acme.json"
+  register: edge_proxy_acme_stat
+
+- name: Create acme.json only if it does not already exist
+  ansible.builtin.file:
+    path: "{{ edge_proxy_dir }}/acme.json"
+    state: touch
+    owner: root
+    group: root
+    mode: "0600"
+  when: not edge_proxy_acme_stat.stat.exists
+
+
+- name: Pull the Traefik image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ edge_proxy_compose_project_name }}"
+      - --file
+      - "{{ edge_proxy_compose_file }}"
+      - pull
+      - traefik
+  args:
+    chdir: "{{ edge_proxy_dir }}"
+  register: edge_proxy_pull
+  changed_when: >-
+    'Downloaded newer image' in edge_proxy_pull.stdout or
+    'Pull complete' in edge_proxy_pull.stdout or
+    'Downloaded newer image' in edge_proxy_pull.stderr or
+    'Pull complete' in edge_proxy_pull.stderr
+
+
+- name: Start Traefik
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ edge_proxy_compose_project_name }}"
+      - --file
+      - "{{ edge_proxy_compose_file }}"
+      - up
+      - --detach
+      - --wait
+      - --wait-timeout
+      - "60"
+      - traefik
+  args:
+    chdir: "{{ edge_proxy_dir }}"
+  register: edge_proxy_up
+  changed_when: >-
+    'Created' in edge_proxy_up.stderr or
+    'Started' in edge_proxy_up.stderr or
+    'Recreated' in edge_proxy_up.stderr

--- a/infrastructure/ansible/oilscope/platform/roles/edge_proxy/templates/dynamic.yml.j2
+++ b/infrastructure/ansible/oilscope/platform/roles/edge_proxy/templates/dynamic.yml.j2
@@ -1,0 +1,15 @@
+http:
+  routers:
+    ui:
+      rule: "Host(`{{ compose_project_config.vms.ui.public_endpoint.hostname }}`)"
+      entryPoints:
+        - websecure
+      service: ui
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    ui:
+      loadBalancer:
+        servers:
+          - url: "http://ui:8080"

--- a/infrastructure/terraform/modules/network/variables.tf
+++ b/infrastructure/terraform/modules/network/variables.tf
@@ -84,13 +84,12 @@ variable "postgresql_port" {
 variable "ui_public_ports" {
   description = "Public TCP ports exposed on the UI VM"
   type        = list(string)
-  default     = ["80", "443"]
+  default     = ["443"]
 
   validation {
     condition = (
-      length(var.ui_public_ports) == 2 &&
-      toset(var.ui_public_ports) == toset(["80", "443"])
+      toset(var.ui_public_ports) == toset(["443"])
     )
-    error_message = "ui_public_ports must contain exactly ports 80 and 443"
+    error_message = "ui_public_ports must contain exactly port 443"
   }
 }

--- a/infrastructure/terraform/project-config.schema.json
+++ b/infrastructure/terraform/project-config.schema.json
@@ -253,6 +253,21 @@
             "type": "string",
             "minLength": 1
           }
+        },
+        "public_endpoint": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["hostname", "acme_email"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "pattern": "^(?=.{1,253}$)([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,63}$"
+            },
+            "acme_email": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+            }
+          }
         }
       },
       "allOf": [
@@ -343,6 +358,7 @@
             "required": ["role"]
           },
           "then": {
+            "required": ["public_endpoint"],
             "properties": {
               "network_tags": {
                 "contains": {

--- a/project-config.example.json
+++ b/project-config.example.json
@@ -104,6 +104,10 @@
       "secret_mappings": {
         "POSTGRES_PASSWORD": "example-db-password",
         "GHCR_TOKEN": "example-ghcr-token"
+      },
+      "public_endpoint": {
+        "hostname": "oilscope.example.com",
+        "acme_email": "example-operator@example.com"
       }
     }
   }


### PR DESCRIPTION
## Title
Add Traefik HTTPS ingress with Let's Encrypt for the UI VM

## Summary
- Adds `public_endpoint.hostname`/`.acme_email` to the project-config schema, scoped per-VM under `vms.ui` (only the UI VM ever needs it), validated via JSON Schema `pattern`s rather than duplicating checks in Ansible.
- Restricts `network.ui_public_ports` to `[443]` only — Terraform no longer opens port 80 on the UI VM's firewall rule.
- Adds a new `oilscope.platform.edge_proxy` role that installs a pinned Traefik image as a separate Compose project (`/opt/oilscope/proxy`), creates the shared `oilscope-edge` Docker network, and gets a certificate via Let's Encrypt's TLS-ALPN-01 challenge (works entirely over port 443, so port 80 was never needed).
- Reuses `compose_project` (now a 5th "workload") to render Traefik's own Compose file, keeping file-rendering logic in one place.
- Updates the UI's own Compose template: drops its host port entirely (no longer directly reachable — Traefik is the only public entry point), joins the shared network, and forces `SESSION_COOKIE_SECURE=true` now that HTTPS is guaranteed.
- Wires `edge_proxy` into `ui.yml` immediately before the `ui` role itself, so Traefik and the shared network exist before the UI container's own Compose file (which now depends on that network) ever starts.